### PR TITLE
Decouple Doppler and Redis modules from implementation through factories

### DIFF
--- a/server/modules/redis-client.spec.js
+++ b/server/modules/redis-client.spec.js
@@ -1,10 +1,18 @@
 require('dotenv').config({ path: '.env.tests' });
 const redis = require('redis');
-const Redis = require('./redis-client');
 const sinon = require('sinon');
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
+const throwsAsync = require('../../test-utilities/chai-throws-async');
 const expect = chai.expect;
+
+const wrappedClient = new redis.RedisClient({});
+
+const redisStub = sinon.stub();
+redisStub.createClient = sinon.stub()
+    .returns(wrappedClient);
+
+const Redis = require('./redis-client')(redisStub)
 
 describe('The redis-client module', function () {
     before(function () {
@@ -17,151 +25,92 @@ describe('The redis-client module', function () {
 
     afterEach(function () {
         this.sandbox.restore();
-    })
+    })    
 
     it('constructor should create wrapped Redis client with correct parameters', function () {
 
-        const createClientStub = this.sandbox.stub(redis, 'createClient')
-            .returns(this.sandbox.createStubInstance(redis.RedisClient));
+        const redisClient = Redis.createClient();
 
-        const redisClient = new Redis();
-
-        expect(createClientStub).to.have.been.callCount(1);
-        expect(createClientStub).to.have.been.calledWith({host: '127.0.0.1', port: 6380, password: 'hello_world'});
+        expect(redisStub.createClient).to.have.been.callCount(1);
+        expect(redisStub.createClient).to.have.been.calledWith({host: '127.0.0.1', port: 6380, password: 'hello_world'});
     });
 
-    it('storeShop should call wrapped method correctly', async function() {
+    it('storeShopAsync should call wrapped method correctly', async function() {
 
-        const hmsetStub = this.sandbox.stub(redis.RedisClient.prototype, "hmset")
-            .callsFake((key, obj, cb) => {
-                cb();
-            });
-
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit");
-
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
-
-        const redisClient = new Redis();
+        this.sandbox.stub(wrappedClient, 'hmset').callsFake((key, obj, cb) => { cb(); });
+        this.sandbox.stub(wrappedClient, 'quit');
         
-        await redisClient.storeShop('my-store.myshopify.com', { accessToken: '1234567890' })
+        const redisClient = Redis.createClient()
+        await redisClient.storeShopAsync('my-store.myshopify.com', { accessToken: '1234567890' })
 
-        expect(hmsetStub).to.have.been.callCount(1);
-        expect(hmsetStub).to.have.been.calledWith('my-store.myshopify.com', { accessToken: '1234567890' });
-        expect(quitStub).to.have.been.callCount(0);
+        expect(wrappedClient.hmset).to.have.been.callCount(1);
+        expect(wrappedClient.hmset).to.have.been.calledWith('my-store.myshopify.com', { accessToken: '1234567890' });
+        expect(wrappedClient.quit).to.have.been.callCount(0);
     });
 
-    it('storeShop should raise the error thrown by redis and close the connection', async function() {
-
+    it('storeShopAsync should raise the error thrown by redis and close the connection', async function() {
         const error = new Error('Forced Error');
-        const hmsetStub = this.sandbox.stub(redis.RedisClient.prototype, "hmset")
-            .throws(error);
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit")
-            .callsFake((cb) => {
-                cb();
-            });
+        this.sandbox.stub(wrappedClient, 'hmset').throws(new Error('Forced Error'));
+        this.sandbox.stub(wrappedClient, 'quit').callsFake((cb) => { cb(); });
 
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
+        const redisClient = Redis.createClient()
 
-        const redisClient = new Redis();
-
-        try {
-            await redisClient.storeShop('my-store.myshopify.com', { accessToken: '1234567890' }, true)
-        } catch (err) {
-            expect(err).to.to.eql(error);
-        }
-
-        expect(quitStub).to.have.been.callCount(1);
-    });
-
-    it('getShop should call wrapped method correctly', async function() {
-
-        const hgetallStub = this.sandbox.stub(redis.RedisClient.prototype, "hgetall")
-            .callsFake((key, cb) => {
-                cb();
-            })
-
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit");
-
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
-
-        const redisClient = new Redis();
+        await throwsAsync(async () => { await redisClient.storeShopAsync('my-store.myshopify.com', { accessToken: '1234567890' }, true) },
+         'Error storing shop my-store.myshopify.com. Error: Forced Error');
         
-        await redisClient.getShop('my-store.myshopify.com')
-
-        expect(hgetallStub).to.have.been.callCount(1);
-        expect(hgetallStub).to.have.been.calledWith('my-store.myshopify.com');
-        expect(quitStub).to.have.been.callCount(0);
+        expect(wrappedClient.quit).to.have.been.callCount(1);
     });
 
-    it('getShop should raise the error thrown by redis and close the connection', async function() {
+    it('getShopAsync should call wrapped method correctly', async function() {
+        this.sandbox.stub(wrappedClient, 'hgetall').callsFake((key, cb) => { cb(); });
+        this.sandbox.stub(wrappedClient, 'quit');
 
-        const error = new Error('Forced Error');
-        const hgetallStub = this.sandbox.stub(redis.RedisClient.prototype, "hgetall")
-            .throws(error);
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit")
-            .callsFake((cb) => {
-                cb();
-            });
-
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
-
-        const redisClient = new Redis();
-
-        try {
-            await redisClient.getShop('my-store.myshopify.com', true);
-        } catch (err) {
-            expect(err).to.to.eql(error);
-        }
-
-        expect(quitStub).to.have.been.callCount(1);
-    });
-
-    it('removeShop should call wrapped method correctly', async function() {
-
-        const delStub = this.sandbox.stub(redis.RedisClient.prototype, "del")
-            .callsFake((key, cb) => {
-                cb();
-            })
-
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit");
-
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
-
-        const redisClient = new Redis();
+        const redisClient = Redis.createClient();
         
-        await redisClient.removeShop('my-store.myshopify.com')
+        await redisClient.getShopAsync('my-store.myshopify.com')
 
-        expect(delStub).to.have.been.callCount(1);
-        expect(delStub).to.have.been.calledWith('my-store.myshopify.com');
-        expect(quitStub).to.have.been.callCount(0);
+        expect(wrappedClient.hgetall).to.have.been.callCount(1);
+        expect(wrappedClient.hgetall).to.have.been.calledWith('my-store.myshopify.com');
+        expect(wrappedClient.quit).to.have.been.callCount(0);
     });
 
-    it('removeShop should raise the error thrown by redis and close the connection', async function() {
-
+    it('getShopAsync should raise the error thrown by redis and close the connection', async function() {
         const error = new Error('Forced Error');
-        const delStub = this.sandbox.stub(redis.RedisClient.prototype, "del")
-            .throws(error);
-        const quitStub = this.sandbox.stub(redis.RedisClient.prototype, "quit")
-            .callsFake((cb) => {
-                cb();
-            });
+        this.sandbox.stub(wrappedClient, 'hgetall').throws(error);
+        this.sandbox.stub(wrappedClient, 'quit').callsFake((cb) => { cb(); });
 
-        this.sandbox.stub(redis, 'createClient')
-            .returns(new redis.RedisClient({}));
+        const redisClient = Redis.createClient()
 
-        const redisClient = new Redis();
+        await throwsAsync(async () => { await redisClient.getShopAsync('my-store.myshopify.com', true) },
+        'Error retrieving shop my-store.myshopify.com. Error: Forced Error');
 
-        try {
-            await redisClient.removeShop('my-store.myshopify.com', true);
-        } catch (err) {
-            expect(err).to.to.eql(error);
-        }
+        expect(wrappedClient.quit).to.have.been.callCount(1);
+    });
 
-        expect(quitStub).to.have.been.callCount(1);
+    it('removeShopAsync should call wrapped method correctly', async function() {
+        this.sandbox.stub(wrappedClient, 'del').callsFake((key, cb) => { cb(); });
+        this.sandbox.stub(wrappedClient, 'quit');
+
+        const redisClient = Redis.createClient()
+        
+        await redisClient.removeShopAsync('my-store.myshopify.com')
+
+        expect(wrappedClient.del).to.have.been.callCount(1);
+        expect(wrappedClient.del).to.have.been.calledWith('my-store.myshopify.com');
+        expect(wrappedClient.quit).to.have.been.callCount(0);
+    });
+
+    it('removeShopAsync should raise the error thrown by redis and close the connection', async function() {
+        const error = new Error('Forced Error');
+        this.sandbox.stub(wrappedClient, 'del').throws(error);
+        this.sandbox.stub(wrappedClient, 'quit').callsFake((cb) => { cb(); });
+
+        const redisClient = Redis.createClient()
+
+
+        await throwsAsync(async () => { await redisClient.removeShopAsync('my-store.myshopify.com', true) },
+        'Error removing shop my-store.myshopify.com. Error: Forced Error');
+
+        expect(wrappedClient.quit).to.have.been.callCount(1);
     });
 })

--- a/test-utilities/chai-throws-async.js
+++ b/test-utilities/chai-throws-async.js
@@ -1,0 +1,14 @@
+const expect = require('chai').expect;
+
+module.exports = async function(fn, expectedErrorMessage) {
+    let thrown = false;
+    try {
+        await fn();
+    } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect(expectedErrorMessage).to.be.eql(error.message);
+        thrown = true;
+    }
+    if (!thrown)
+        throw new Error(`Was expecting en error with message ${expectedErrorMessage} to be thrown but none exception has been thrown.`);
+}


### PR DESCRIPTION
## Bacrkground

I'm currently working in the creation of the routes (endpoints) and using the previously created modules (Redis and Doppler clients). I realized, when trying to create the unit tests, that these implementations are so tied to the libraries that perform the connection itself (node-fetch and redis). When creating the stubs/mocks for the modules it worked correctly since Sinon works OK for direct dependencies, but now we have to test modules that have dependencies with other modules that have dependencies with these libraries, so it was so hard to mock up these. For example if we have a module that performs the following operation:

```javascript
const Redis = require('redis-client'); // this, in turn, includes 'redis'

const redisClient = new RedisClient();
let o = redisClient.getObject()
```
The unit test for this will attempt to connect with Redis, because the constructor does it. So the idea behind this refactor is the following:

- inject the function/library that performs the connection to our modules
- export a factory instead of the class to create the objects instead of using 'new' everywhere.

By doing this the previous snippet will become something like this:
```javascript
const redisConnection = require('redis')
const Redis = require('redis-client')(redisConnection); // here we inject the library

const redisClient = Redis.createClient(); // the factory
let o = redisClient.getObject()
```
So far, it gave good results when mocking up components in the unit tests, and they are now much easier to write. In addition we get more decoupled components. 

I also added rome other minor improvements.

## Changes done

- Inject connection/fetching libraries to Doppler and Redis modules.
- Export factory in the Doppler and Redis modules.
- Rename Redis methods with suffix 'Async'.
- Fix/rewrite unit tests.
- Create test-utilities module with common logic for all tests.

