### PR TITLE
Use Docker to run the system locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ spin up an embedded Shopify app using Node and Express.js and get started using 
 This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 
 ## Features
+
 - [x] React app using [Polaris](https://polaris.shopify.com/)
 - [x] Shopify Authentication
 - [x] Get API data from Shopify and pass it to React
@@ -14,6 +15,7 @@ This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 - [x] Example webhook set up
 
 ## Commands
+
 - `yarn run start` run the server
 - `yarn run dev` run it in development mode with hotreloading
 - `yarn run prod` run it in production mode with compiled assets
@@ -22,15 +24,18 @@ This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 ## Running the project locally
 
 ### Install project dependencies
+
 - Install Node.js version 8.1.0 or higher. We recommend using [nvm](https://github.com/creationix/nvm) to manage Node versions.
 - Install the [Yarn.js](https://yarnpkg.com/en/docs/install) package manager. Yarn is an alternative to npm that is faster and more reliable.
 - Install project dependencies with `yarn install`
 
 ### Allow your app to talk to Shopify
+
 - Create a tunnel to localhost:3000 using [forward](https://forwardhq.com/) or [ngrok](https://ngrok.com/)
   - Note the tunnel url (we’ll refer to it as `HOST`)
 
 ### Register your app in the Partner Dashboard
+
 - Sign into your [Shopify Partner Dashboard](https://partners.shopify.com/organizations)
 - Click 'Apps' in the sidebar and create a new app
 - Set the app url to `{{ HOST }}/`
@@ -38,6 +43,7 @@ This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 - Go to extensions tab and enable “Embed in Shopify admin”
 
 ### Configure and add to a store
+
 - Rename `.env.example` to `.env` and
   - Set Add HOST from your tunnel service as `SHOPIFY_APP_HOST`
   - Add the api key from partners dash as `SHOPIFY_APP_KEY`
@@ -52,6 +58,7 @@ This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 There are three main sections that provide the foundations for this example. They are organized as follows:
 
 ### `server`
+
 This folder provides the Express.js server as well as a few basic views.
 The server provides some example endpoints that demonstrate mounting the Shopify routes for installation and authentication, hosting the React app
 with an API proxy, and a basic webhook.
@@ -59,12 +66,15 @@ with an API proxy, and a basic webhook.
 The code here is mostly glue code, with the bulk of the actual functionality provided by the modules in `shopify-express`.
 
 ### `shopify-express`
+
 This example app consumes the [shopify-express](https://github.com/shopify/shopify-express-app) library to quickly connect to the Shopify API.
 
 ### `shopify-api-node`
+
 This example app uses the Official [shopify-api-node](https://github.com/MONEI/Shopify-api-node) library to connect to the Shopify API.
 
 ### `client`
+
 This folder contains the UI demo using Polaris React components and Redux to manage app state.
 It has two subfolders called `store` and `actions` which are Redux concepts.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ This example app uses Node, Express, Webpack, React, Redux, and Shopify/polaris
 
 ## Running the project locally
 
+### Run easily with Docker without install dependencies
+
+1. Define `SHOPIFY_APP_SECRET` as environment variable with the right value.
+2. Run `./run-with-docker.sh`
+3. Open <http://localhost:3000>
+
+To try it inside Shopify, it will be necessary to create the tunnel and register the app as it is described in following sections.
+
 ### Install project dependencies
 
 - Install Node.js version 8.1.0 or higher. We recommend using [nvm](https://github.com/creationix/nvm) to manage Node versions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3"
+services:
+  redis:
+    image: redis:4-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    hostname: redis
+    networks:
+      - redis-net
+    volumes:
+      - redis-data:/data
+  app:
+    image: node:8-alpine
+    working_dir: /work
+    command: >
+      /bin/sh -c "
+      yarn install 
+      && yarn run dev;
+      "
+    environment:
+      - NODE_ENV=development
+      - RHOST=redis
+      - SHOPIFY_APP_HOST=http://localhost
+      - SHOPIFY_APP_KEY=ab60395f0cef794b959ac302f52f28e2
+      - SHOPIFY_APP_SECRET # Define this as an environment variable in Docker in host
+      - SHOPIFY_APP_PORT=3000
+      - SHOPIFY_APP_STORAGE_ENGINE=memory
+      - REDIS_HOST=redis
+      - REDIS_PASSWORD=
+      - REDIS_PORT=6379
+    ports:
+      - 3000:3000
+    networks:
+      - redis-net
+    depends_on:
+      - redis
+    volumes:
+      - .:/work
+
+networks:
+  redis-net:
+
+volumes:
+  redis-data:

--- a/run-w-docker.sh
+++ b/run-w-docker.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+docker-compose up


### PR DESCRIPTION
Hi @pbarrios,

In this PR I am trying to simplify running your _Shopify Doppler Integration_ using _Docker_.

I am not sure if it is enough to run locally because it seems that it is not easy to run it without _"Shopify wrapper"_. I were thinking about using _hosts file_ + _a HTTPS inverse proxy Docker image_ + _forcing to accept a self-signed certificate_, but there should be a better way to do it based on [this code comment](https://github.com/MakingSense/doppler-for-shopify/blob/d40b0beca61e4d5dbf7a3842a32f3a61e5426081/server/views/app.ejs#L20-L25) that you shared with me.

So, but the moment I think that it is enough, and it is also the first step in order to have a build script based in Docker as [we already have in MSEditor](https://github.com/MakingSense/MSEditor/tree/develop/refactor#docker-and-ci)

![2018-05-10_08-15-05](https://user-images.githubusercontent.com/1157864/39882477-4f4a1cd4-545a-11e8-8d9e-1c2881e988fa.png)

Do you think that it could be merged?