### PR TITLE
Add routes modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -176,6 +186,12 @@
       "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -198,6 +214,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
       "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "minimatch": {
@@ -253,6 +275,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -2968,6 +2996,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
@@ -2983,6 +3017,26 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "proxyquire": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
+      "integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.5.0"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -2990,9 +3044,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.3.tgz",
-      "integrity": "sha512-kzBkET1Hf0r0J4uVnlicuAEiq9nnhPrEHZWS0mds+5EaB9rA0XoliIkLaqkBNU9lwPuJACo/velUQQOmTRJtUw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.7.tgz",
+      "integrity": "sha512-GvNLrwpvLZ8jIMZBUhHGUZDq5wlUdceJWyHvZDmqBxnjazpxY1L0FNbGBX6VpcOEoQ8Q4XMWFzm2myJMvx+VjA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
@@ -3025,6 +3079,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
       "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
+      "dev": true
+    },
+    "sinon-express-mock": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sinon-express-mock/-/sinon-express-mock-2.0.0.tgz",
+      "integrity": "sha512-u8Y4d4AzkMXtrJHyDpLUE5rqqDgTHLNm7nz1hl2Tu0qFeZGifoh3vKPcx4rVmr0ZZwu4qWk8MZ5v+SaKMb/Jgg==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pretty": "prettier --single-quote --trailing-comma es5 --write {client,bin,config,server}{/*,/**/*}.js",
     "precommit": "yarn run pretty",
     "test": "npm run test-unit",
-    "test-unit": "cross-env NODE_ENV=test nyc --reporter=text mocha --require co-mocha './server/modules/*.spec.js'"
+    "test-unit": "cross-env NODE_ENV=test nyc --reporter=text mocha --require co-mocha './server/**/*.spec.js'"
   },
   "engines": {
     "node": ">= 8.1.0"
@@ -73,8 +73,9 @@
     "postcss-loader": "^2.0.6",
     "prettier": "^1.5.2",
     "react-hot-loader": "^3.0.0-beta.7",
-    "sinon": "^5.0.3",
+    "sinon": "^5.0.7",
     "sinon-chai": "^3.0.0",
+    "sinon-express-mock": "^2.0.0",
     "style-loader": "^0.18.2",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"

--- a/server/modules/shopify-extras.js
+++ b/server/modules/shopify-extras.js
@@ -1,3 +1,11 @@
+const ShopifyAPIClient = require('shopify-api-node');
+
+class ShopifyAPIClientFactory {
+  createClient(shopDomain, accessToken) {
+    return new ShopifyAPIClient({ shopName: shopDomain, accessToken: accessToken });
+  }
+}
+
 module.exports = {
  customerFields: [
       {
@@ -192,5 +200,7 @@ module.exports = {
         sample: 'Argentina',
         type: 'string'
       }
-  ]
+  ],
+  shopifyAPIClientFactory: ShopifyAPIClientFactory
 }
+

--- a/server/routes/app-routes.js
+++ b/server/routes/app-routes.js
@@ -1,0 +1,134 @@
+const shopifyFields = require ('../modules/shopify-extras').customerFields;
+
+class AppRoutes {
+
+  constructor(redisClientFactory, dopplerClientFactory, shopifyClientFactory){
+    this.redisClientFactory = redisClientFactory;
+    this.dopplerClientFactory = dopplerClientFactory;
+    this.shopifyClientFactory = shopifyClientFactory;
+  }
+
+  async home(request, response) {
+      const { session: { shop, accessToken } } = request;
+
+      const redis = this.redisClientFactory.createClient();
+      const shopInstance = await redis.getShopAsync(shop, true);
+      
+      // TODO: should we move this to middleware in order to filter all requests?
+      if (shopInstance === null || shopInstance.accessToken !== accessToken) {
+        response.redirect(`/shopify/auth?shop=${shop}`);
+        return;
+      }
+
+      response.render('app', {
+        title: 'Doppler for Shopify',
+        apiKey: process.env.SHOPIFY_APP_KEY,
+        shop: shop,
+        dopplerAccountName: shopInstance.dopplerAccountName
+      });
+  }
+
+  async connectToDoppler(request, response) {
+    const { session: { shop }, body: { dopplerAccountName, dopplerApiKey } } = request;
+    
+    const doppler = this.dopplerClientFactory.createClient(dopplerAccountName, dopplerApiKey);
+    const validCredentials = await doppler.AreCredentialsValidAsync();
+    
+    if (!validCredentials) {
+      response.json({success: false, details: 'Invalid credentials'});
+      return;
+    }
+
+    const redis = this.redisClientFactory.createClient();
+    await redis.storeShopAsync(shop, { dopplerAccountName, dopplerApiKey }, true);
+    response.json({success: true});
+  }
+
+  async getDopplerLists(request, response) {
+      const { session: { shop } } = request;
+      
+      const redis = this.redisClientFactory.createClient();
+      const shopInstance = await redis.getShopAsync(shop, true);
+
+      const doppler = this.dopplerClientFactory.createClient(shopInstance.dopplerAccountName, shopInstance.dopplerApiKey);
+      const lists = await doppler.getListsAsync();
+
+      response.json(lists);
+  }
+
+  async createDopplerList(request, response) {
+    const { session: { shop }, body: { name } } = request;
+    
+    const redis = this.redisClientFactory.createClient();
+    const shopInstance = await redis.getShopAsync(shop, true);
+
+    const doppler = this.dopplerClientFactory.createClient(shopInstance.dopplerAccountName, shopInstance.dopplerApiKey);
+    const lists = await doppler.createListAsync(name);
+
+    response.json({success:true});
+  }
+
+  async setDopplerList(request, response) {
+    const { session: { shop }, body: { dopplerListId } } = request;
+    
+    const redis = this.redisClientFactory.createClient();
+    await redis.storeShopAsync(shop, { dopplerListId }, true);
+
+    response.json({success:true});
+  }
+  
+  async getFields(request, response) {
+    const { session: { shop } } = request;
+    
+    const redis = this.redisClientFactory.createClient();
+    const shopInstance = await redis.getShopAsync(shop, true);
+
+    const doppler = this.dopplerClientFactory.createClient(shopInstance.dopplerAccountName, shopInstance.dopplerApiKey);
+    const dopplerFields = await doppler.getFieldsAsync();
+
+    response.json({ shopifyFields, dopplerFields });
+  }
+
+  async setFieldsMapping(request, response) {
+    const { session: { shop }, body: { fieldsMapping } } = request;
+    
+    const redis = this.redisClientFactory.createClient();
+    const shopInstance = await redis.storeShopAsync(shop, { fieldsMapping }, true);
+
+    response.json({ success: true });
+  }
+
+  //TODO: this is a heavyweight process, maybe we should do it all asynchronous
+  async synchronizeCustomers(request, response) { 
+    const { session: { shop, accessToken } } = request;
+
+    const shopify = this.shopifyClientFactory.createClient(shop, accessToken);
+    
+    // TODO: if webhook creation fails, should we continue with the synchronization?
+    await shopify.webhook.create({
+      topic: 'customers/create',
+      address: `${process.env.SHOPIFY_APP_HOST}/hooks/customers/created`,
+      format: 'json'
+    });
+        
+    const customers = await shopify.customer.list();
+
+    const redis = this.redisClientFactory.createClient();
+    const shopInstance = await redis.getShopAsync(shop);
+
+    const doppler = this.dopplerClientFactory.createClient(shopInstance.dopplerAccountName, shopInstance.dopplerApiKey);
+    
+    const importTaskId = await doppler.importSubscribersAsync(
+      customers, 
+      shopInstance.dopplerListId,
+      shop, 
+      JSON.parse(shopInstance.fieldsMapping)
+    );
+
+    await redis.storeShopAsync(shop, { importTaskId }, true);
+
+    response.json({success: true});
+  }
+}
+
+module.exports = AppRoutes;

--- a/server/routes/app-routes.spec.js
+++ b/server/routes/app-routes.spec.js
@@ -1,0 +1,327 @@
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+const AppRoutes = require('./app-routes');
+const sinonMock = require('sinon-express-mock');
+const modulesMocks = require('../../test-utilities/modules-mock');
+const expect = chai.expect;
+
+const redisClientFactoryStub = { createClient: () => { return modulesMocks.redisClient; }};
+const dopplerClientFactoryStub = { createClient: () => { return modulesMocks.dopplerClient; }};
+const shopifyClientFactoryStub = { createClient: () => { return modulesMocks.shopifyClient; }};
+
+describe('The app routes', function () {
+    before(function () {
+        chai.use(sinonChai);
+    });
+    
+    beforeEach(function () {
+        this.sandbox = sinon.createSandbox();
+    });
+    
+    afterEach(function () {
+        this.sandbox.restore();
+    });
+
+    it('home should render the home page when shop is stored in Redis correctly', async function () {
+        const request = sinonMock.mockReq({ session: { accessToken: 'fb5d67a5bd67ab5d67ab5d', shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({ 
+                accessToken: 'fb5d67a5bd67ab5d67ab5d',
+                dopplerAccountName: 'user@example.com'
+            }));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.home(request, response);
+
+        expect(response.render).to.be.called.calledWithExactly('app', {
+            title: 'Doppler for Shopify',
+            apiKey: '1234567890',
+            shop: 'store.myshopify.com',
+            dopplerAccountName: 'user@example.com'
+        });
+
+        expect(modulesMocks.redisClient.getShopAsync).to.be.called.calledWithExactly('store.myshopify.com', true);
+    });
+
+    it('home should redirect to authorization page when shop is not stored in Redis', async function () {
+        const request = sinonMock.mockReq({ session: { accessToken: 'fb5d67a5bd67ab5d67ab5d', shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve(null));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.home(request, response);
+
+        expect(response.redirect).to.be.called.calledWithExactly("/shopify/auth?shop=store.myshopify.com")
+        expect(response.render).to.have.been.callCount(0);
+    });
+
+    
+    it('home should redirect to authorization page when session and Redis access tokens do not match', async function () {
+        const request = sinonMock.mockReq({ session: { accessToken: 'fb5d67a5bd67ab5d67ab5d', shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({ accessToken: 'ae768b8c78d68a54565434' }));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.home(request, response);
+
+        expect(response.redirect).to.be.called.calledWithExactly("/shopify/auth?shop=store.myshopify.com")
+        expect(response.render).to.have.been.callCount(0);
+    });
+
+    it('connectToDoppler should store the Doppler account name and API key when credentials are valid', async function () {
+        const request = sinonMock.mockReq(
+            {
+                session: { shop: 'store.myshopify.com' },
+                body: { dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', dopplerAccountName: 'user@example.com' }
+            });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+        this.sandbox.stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
+            .returns(Promise.resolve(true));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.connectToDoppler(request, response);
+
+        expect(modulesMocks.dopplerClient.AreCredentialsValidAsync).to.have.been.callCount(1);
+        expect(modulesMocks.redisClient.storeShopAsync).to.be.called.calledWithExactly('store.myshopify.com', {dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', dopplerAccountName: 'user@example.com'}, true);
+        expect(response.json).to.be.called.calledWithExactly({success: true});
+    });
+
+    it('connectToDoppler should return "Invalid credentials" when Doppler credentials are invalid', async function () {
+        const request = sinonMock.mockReq(
+            {
+                session: { shop: 'store.myshopify.com' },
+                body: { dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', dopplerAccountName: 'user@example.com' }
+            });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+        this.sandbox.stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
+            .returns(Promise.resolve(false));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.connectToDoppler(request, response);
+
+        expect(modulesMocks.dopplerClient.AreCredentialsValidAsync).to.have.been.callCount(1);
+        expect(modulesMocks.redisClient.storeShopAsync).to.have.been.callCount(0);
+        expect(response.json).to.be.called.calledWithExactly({success: false, details: 'Invalid credentials'});
+    });
+
+    it('getDopplerLists should return the lists from Doppler', async function () {
+        const request = sinonMock.mockReq({ session: { shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({ 
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com'
+            }));
+
+        this.sandbox.stub(modulesMocks.dopplerClient, 'getListsAsync')
+            .returns(Promise.resolve({
+                items: [
+                    { listId: 1459381, name: 'shopify' },
+                    { listId: 1222381, name: 'marketing' },
+                    { listId: 1170501, name: 'development' }
+                ],
+                itemsCount: 3
+                }));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.getDopplerLists(request, response);
+
+        expect(modulesMocks.dopplerClient.getListsAsync).to.have.been.callCount(1);
+        expect(modulesMocks.redisClient.getShopAsync).to.be.called.calledWithExactly('store.myshopify.com', true);
+        expect(response.json).to.be.called.calledWithExactly({
+            items: [
+                { listId: 1459381, name: 'shopify' },
+                { listId: 1222381, name: 'marketing' },
+                { listId: 1170501, name: 'development' }
+            ],
+            itemsCount: 3
+        });
+    });
+
+    it('createDopplerList should create the list in Doppler', async function () {
+        const request = sinonMock.mockReq(
+            {
+                session: { shop: 'store.myshopify.com' },
+                body: { name: 'Fresh list' }
+            });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({ 
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com'
+            }));
+
+        this.sandbox.stub(modulesMocks.dopplerClient, 'createListAsync');
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.createDopplerList(request, response);
+
+        expect(modulesMocks.dopplerClient.createListAsync).to.be.called.calledWithExactly('Fresh list');
+        expect(modulesMocks.redisClient.getShopAsync).to.be.called.calledWithExactly('store.myshopify.com', true);
+        expect(response.json).to.be.called.calledWithExactly({success: true});
+    });
+
+    it('setDopplerList should store the doppler list id in Redis', async function () {
+        const request = sinonMock.mockReq(
+            {
+                session: { shop: 'store.myshopify.com' },
+                body: { dopplerListId: 15457 }
+            });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.setDopplerList(request, response);
+
+        expect(modulesMocks.redisClient.storeShopAsync).to.be.called.calledWithExactly('store.myshopify.com', { dopplerListId: 15457 }, true);
+        expect(response.json).to.be.called.calledWithExactly({success: true});
+    });
+
+    it('getFields should return Shopify and Doppler fields', async function () {
+        const request = sinonMock.mockReq({ session: { shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({ 
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com'
+            }));
+        this.sandbox.stub(modulesMocks.dopplerClient, 'getFieldsAsync')
+            .returns(Promise.resolve([
+                {
+                    name: "FIRSTNAME",
+                    predefined: true,
+                    private: false,
+                    readonly: false,
+                    type: "string"
+                },
+                {
+                    name: "LASTNAME",
+                    predefined: true,
+                    private: false,
+                    readonly: false,
+                    type: "string"
+                }]));
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.getFields(request, response)
+
+        expect(modulesMocks.redisClient.getShopAsync).to.be.called.calledWithExactly('store.myshopify.com', true);
+        expect(response.json.args[0][0].shopifyFields.length).to.be.eqls(32);
+        expect(response.json.args[0][0].dopplerFields.length).to.be.eqls(2);
+    });
+
+    it('setFieldsMapping should store the fieldMapping in redis', async function () {
+        const request = sinonMock.mockReq({ 
+            session: { shop: 'store.myshopify.com' },
+            body: {
+                fieldsMapping: [
+                    { shopify: 'first_name', doppler: 'FIRSTNAME' },
+                    { shopify: 'last_name', doppler: 'LASTNAME' }
+                ]
+            }
+        });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.setFieldsMapping(request, response)
+
+        expect(modulesMocks.redisClient.storeShopAsync).to.be.called.calledWithExactly('store.myshopify.com',{
+            fieldsMapping: [
+                { shopify: 'first_name', doppler: 'FIRSTNAME' },
+                { shopify: 'last_name', doppler: 'LASTNAME' }
+            ]
+        }, true);
+        expect(response.json).to.be.called.calledWithExactly({success: true});
+    });
+
+    it('synchronizeCustomers should perform the synchronization process', async function() {
+        const request = sinonMock.mockReq({ session: { accessToken: 'fb5d67a5bd67ab5d67ab5d', shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.shopifyClient.webhook, 'create');
+        this.sandbox.stub(modulesMocks.shopifyClient.customer, 'list')
+            .returns(Promise.resolve([
+                { 	
+                    id: 623558295613,
+                    email: 'jonsnow@example.com',
+                    first_name: 'Jon',
+                    last_name: 'Snow',
+                    default_address:
+                    {  
+                       company: 'Winterfell'
+                    }
+                },
+                { 	
+                    id: 546813203473,
+                    email: 'nickrivers@example.com',
+                    first_name: 'Nick',
+                    last_name: 'Rivers',
+                    default_address:
+                    {  
+                       company: 'Top Secret'
+                    }
+                }
+            ]));        
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com',
+                dopplerListId: 1456877,
+                fieldsMapping: '[{"shopify":"first_name","doppler":"FIRSTNAME"},{"shopify":"last_name","doppler":"LASTNAME"}]'
+            }));
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+        
+        this.sandbox.stub(modulesMocks.dopplerClient, 'importSubscribersAsync')
+            .returns(Promise.resolve('importTask-123456'));
+        
+        const appRoutes = new AppRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.synchronizeCustomers(request, response)
+
+        expect(modulesMocks.shopifyClient.webhook.create).to.be.called.calledWithExactly({
+            topic: 'customers/create',
+            address: 'https://shopify.fromdoppler.com/hooks/customers/created',
+            format: 'json'
+          });
+        expect(modulesMocks.shopifyClient.customer.list).to.have.been.callCount(1);
+        expect(modulesMocks.redisClient.getShopAsync).to.be.called.calledWithExactly('store.myshopify.com');
+        expect(modulesMocks.dopplerClient.importSubscribersAsync).to.be.called.calledWithExactly(
+            [
+                { 	
+                    id: 623558295613,
+                    email: 'jonsnow@example.com',
+                    first_name: 'Jon',
+                    last_name: 'Snow',
+                    default_address:
+                    {  
+                       company: 'Winterfell'
+                    }
+                },
+                { 	
+                    id: 546813203473,
+                    email: 'nickrivers@example.com',
+                    first_name: 'Nick',
+                    last_name: 'Rivers',
+                    default_address:
+                    {  
+                       company: 'Top Secret'
+                    }
+                }
+            ],
+            1456877,
+            'store.myshopify.com',
+            [{"shopify":"first_name","doppler":"FIRSTNAME"},{"shopify":"last_name","doppler":"LASTNAME"}]
+        );
+        expect(modulesMocks.redisClient.storeShopAsync).to.be.calledWithExactly('store.myshopify.com', { importTaskId: 'importTask-123456' }, true);
+        expect(response.json).to.be.calledWithExactly({ success:true });
+    });
+});

--- a/server/routes/hooks-routes.js
+++ b/server/routes/hooks-routes.js
@@ -1,0 +1,44 @@
+class HooksRoutes {
+
+    constructor(redisClientFactory, dopplerClientFactory, shopifyClientFactory) {
+      this.redisClientFactory = redisClientFactory;
+      this.dopplerClientFactory = dopplerClientFactory;
+      this.shopifyClientFactory = shopifyClientFactory;
+    }
+
+    async appUninstalled(error, request) {
+        if (error) {
+            console.error(error);
+            return;
+        }
+        const jsonPayload = JSON.parse(request.body);
+        const redis = this.redisClientFactory.createClient();
+        await redis.removeShopAsync(jsonPayload.domain, true);
+    }
+
+    async customerCreated(error, request) {
+        if (error) {
+            console.error(error);
+            return;
+        }
+
+        const redis = this.redisClientFactory.createClient();
+        const shopDomain = request.get('X-Shopify-Shop-Domain');
+        const shopInstance = await redis.getShopAsync(shopDomain, true);
+        
+        if (shopInstance == null || shopInstance.dopplerListId == null) return;
+
+        const customer = JSON.parse(request.body);
+        const doppler = this.dopplerClientFactory.createClient();
+        await doppler.createSubscriberAsync(customer, shopInstance.dopplerListId, JSON.parse(shopInstance.fieldsMapping));
+    }
+
+    async dopplerImportTaskCompleted(request, response) {
+        const shop = request.query.shop;
+        const redis = this.redisClientFactory.createClient();
+        await redis.storeShopAsync(shop, { synchronizationCompleted: true }, true);
+        response.send('Thank you!');
+    }
+}
+
+module.exports = HooksRoutes;

--- a/server/routes/hooks-routes.spec.js
+++ b/server/routes/hooks-routes.spec.js
@@ -1,0 +1,132 @@
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+const HookRoutes = require('./hooks-routes');
+const sinonMock = require('sinon-express-mock');
+const modulesMocks = require('../../test-utilities/modules-mock');
+const expect = chai.expect;
+
+const redisClientFactoryStub = { createClient: () => { return modulesMocks.redisClient; }};
+const dopplerClientFactoryStub = { createClient: () => { return modulesMocks.dopplerClient; }};
+const shopifyClientFactoryStub = { createClient: () => { return modulesMocks.shopifyClient; }};
+
+describe('The hooks routes', function () {
+
+    before(function () {
+        chai.use(sinonChai);
+    });
+    
+    beforeEach(function () {
+        this.sandbox = sinon.createSandbox();
+    });
+    
+    afterEach(function () {
+        this.sandbox.restore();
+    });
+
+    it('appUninstalled should remove the data of the application', async function(){
+        const request = sinonMock.mockReq({ body: '{"domain":"store.myshopify.com"}' });
+        this.sandbox.stub(modulesMocks.redisClient, 'removeShopAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.appUninstalled(undefined, request);
+        
+        expect(modulesMocks.redisClient.removeShopAsync).to.be.calledWithExactly('store.myshopify.com', true);
+    });
+
+    it('appUninstalled should not perform any operation when there is an error', async function(){
+        const request = sinonMock.mockReq();
+        this.sandbox.stub(modulesMocks.redisClient, 'removeShopAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.appUninstalled(new Error('Forced Error'), request);
+        
+        expect(modulesMocks.redisClient.removeShopAsync).to.have.been.callCount(0);
+    });
+
+    it('customerCreated create a subscriber in Doppler', async function(){
+        const request = sinonMock.mockReq({ body: '{"id":623558295613,"email":"jonsnow@example.com","first_name":"Jon","last_name":"Snow","default_address":{"company":"Winterfell"}}' });
+        request.get.returns('store.myshopify.com');
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com',
+                dopplerListId: 1456877,
+                fieldsMapping: '[{"shopify":"first_name","doppler":"FIRSTNAME"},{"shopify":"last_name","doppler":"LASTNAME"}]'
+            }));
+        this.sandbox.stub(modulesMocks.dopplerClient, 'createSubscriberAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.customerCreated(undefined, request);
+        
+        expect(request.get).to.be.calledWithExactly('X-Shopify-Shop-Domain');
+        expect(modulesMocks.redisClient.getShopAsync).to.be.calledWithExactly('store.myshopify.com', true);
+        expect(modulesMocks.dopplerClient.createSubscriberAsync).to.be.calledWithExactly({
+            default_address: { company: "Winterfell" },
+            email: "jonsnow@example.com",
+            first_name: "Jon",
+            id: 623558295613,
+            last_name: "Snow"
+          }, 1456877, [{ doppler: "FIRSTNAME", shopify: "first_name" }, { doppler: "LASTNAME", shopify: "last_name" }]);
+    });
+    
+    it('customerCreated should not perform any operation when there is an error', async function(){
+        const request = sinonMock.mockReq();
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+        this.sandbox.stub(modulesMocks.dopplerClient, 'createSubscriberAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.customerCreated(new Error('Forced Error'), request);
+        
+        expect(modulesMocks.redisClient.getShopAsync).have.been.callCount(0);
+        expect(modulesMocks.dopplerClient.createSubscriberAsync).have.been.callCount(0);
+    });
+
+    it('customerCreated should not perform any operation when there is not a Doppler list set', async function(){
+        const request = sinonMock.mockReq({ body: '{"id":623558295613,"email":"jonsnow@example.com","first_name":"Jon","last_name":"Snow","default_address":{"company":"Winterfell"}}' });
+        request.get.returns('store.myshopify.com');
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve({
+                accessToken: 'ae768b8c78d68a54565434',
+                dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A', 
+                dopplerAccountName: 'user@example.com',
+                dopplerListId: null,
+                fieldsMapping: '[{"shopify":"first_name","doppler":"FIRSTNAME"},{"shopify":"last_name","doppler":"LASTNAME"}]'
+            }));
+        this.sandbox.stub(modulesMocks.dopplerClient, 'createSubscriberAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.customerCreated(undefined, request);
+        
+        expect(request.get).to.be.calledWithExactly('X-Shopify-Shop-Domain');
+        expect(modulesMocks.redisClient.getShopAsync).to.be.calledWithExactly('store.myshopify.com', true);
+        expect(modulesMocks.dopplerClient.createSubscriberAsync).to.have.been.callCount(0);
+    });
+
+    it('customerCreated should not perform any operation when there is not a shop stored in Redis', async function(){
+        const request = sinonMock.mockReq({ body: '{"id":623558295613,"email":"jonsnow@example.com","first_name":"Jon","last_name":"Snow","default_address":{"company":"Winterfell"}}' });
+        request.get.returns('store.myshopify.com');
+        this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+            .returns(Promise.resolve(null));
+        this.sandbox.stub(modulesMocks.dopplerClient, 'createSubscriberAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.customerCreated(undefined, request);
+        
+        expect(request.get).to.be.calledWithExactly('X-Shopify-Shop-Domain');
+        expect(modulesMocks.redisClient.getShopAsync).to.be.calledWithExactly('store.myshopify.com', true);
+        expect(modulesMocks.dopplerClient.createSubscriberAsync).to.have.been.callCount(0);
+    });
+
+    it('dopplerImportTaskCompleted should set the synchronization status correctly', async function(){
+        const request = sinonMock.mockReq({ query: { shop: 'store.myshopify.com' } });
+        const response = sinonMock.mockRes();
+        this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
+
+        const appRoutes = new HookRoutes(redisClientFactoryStub, dopplerClientFactoryStub, shopifyClientFactoryStub);
+        await appRoutes.dopplerImportTaskCompleted(request, response);
+        
+        expect(modulesMocks.redisClient.storeShopAsync).to.be.calledWithExactly('store.myshopify.com', { synchronizationCompleted: true}, true);
+    });
+});

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -1,0 +1,23 @@
+module.exports = {
+    redisClient: {
+        getShopAsync: async function () {},
+        storeShopAsync: async function () {},
+        removeShopAsync: async function () {}
+    },
+    dopplerClient: {
+        AreCredentialsValidAsync: async function () {},
+        getListsAsync: async function () {},
+        createListAsync: async function () {},
+        getFieldsAsync: async function () {},
+        importSubscribersAsync: async function () {},
+        createSubscriberAsync: async function () {}
+    },
+    shopifyClient: {
+        webhook: {
+            create: async function () {}
+        },
+        customer: {
+            list: async function () {}
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6022,9 +6022,13 @@ sinon-chai@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.0.0.tgz#d5cbd70fa71031edd96b528e0eed4038fcc99f29"
 
-sinon@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.3.tgz#9950f1616187ff0cd7d75a60d66bc27fed569945"
+sinon-express-mock@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sinon-express-mock/-/sinon-express-mock-2.0.0.tgz#eef617283e03e063c008e753f470e1a7858dc663"
+
+sinon@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.7.tgz#3bded6a73613ccc9e512e20246ced69a27c27dab"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
     diff "^3.1.0"


### PR DESCRIPTION
## Background

Hello! In this PR I added the controllers for the requests to the app. They are the handlers for the endpoints. The idea of having this controllers as a separate module  (instead of define the function in the express route) is to improve the cohesion by  perform here all the logic and the business rules, and leave other aspects, like security concerns or data formats in the middlewares that express provides. We can see this controllers (or routes) as the orchestrator for the modules in a layer below (redis, doppler and shopify). The next step is to define the endpoints, and bind these routes to the endpoints definition. It will be something like:
```javascript
// file server/index.js

const appRoutes = new AppRoutes(redisClientFactory, dopplerClientFactory, shopifyClientFactory);
app.get('/doppler-lists',  withShop({authBaseUrl: '/shopify'}), appRoutes.getDopplerLists)
app.post('/synchronize-customers',  withShop({authBaseUrl: '/shopify'}), appRoutes.synchronizeCustomers)
//...
```

I splitted the routes in two modules: 

- AppRoutes: for handling the app endpoints. These will be called by the UI.
- HooksRoutes: for handling the webhooks from Shopify and Doppler

