### PR TITLE
Add endpoint to retrieve all associated shops to a Doppler account

### DIFF
--- a/server/controllers/app.controller.js
+++ b/server/controllers/app.controller.js
@@ -81,7 +81,7 @@ class AppController {
     const redis = this.redisClientFactory.createClient();
     await redis.storeShopAsync(
       shop,
-      { dopplerAccountName, dopplerApiKey },
+      { dopplerAccountName, dopplerApiKey, connectedOn: new Date().toISOString() },
       true
     );
     response.sendStatus(200);

--- a/server/controllers/app.controller.spec.js
+++ b/server/controllers/app.controller.spec.js
@@ -157,7 +157,7 @@ describe('The app controller', function() {
     ).to.have.been.callCount(1);
     expect(
       modulesMocks.redisClient.storeShopAsync
-    ).to.be.called.calledWithExactly(
+    ).to.be.called.calledWithMatch(
       'store.myshopify.com',
       {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',

--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -1,0 +1,27 @@
+class DopplerController {
+    constructor(redisClientFactory) {
+      this.redisClientFactory = redisClientFactory;
+    }
+
+    async getShops(request, response) {
+        const {
+            session: { dopplerApiKey }
+        } = request;
+
+        const redis = this.redisClientFactory.createClient();
+        const shops = (await redis.getShopsAsync(dopplerApiKey, false))
+        .map(async shopName => {
+            let shop = await redis.getShopAsync(shopName);
+            return {
+                shop: shopName,
+                accessToken: shop.accessToken,
+                connectedOn: shop.connectedOn
+            };
+        });
+        
+        response.json(await Promise.all(shops));
+        await redis.quitAsync();
+    }
+}
+
+module.exports = DopplerController;

--- a/server/controllers/doppler.controller.spec.js
+++ b/server/controllers/doppler.controller.spec.js
@@ -1,0 +1,69 @@
+const chai = require('chai');
+const sinonChai = require('sinon-chai');
+const sinon = require('sinon');
+const DopplerController = require('./doppler.controller');
+const sinonMock = require('sinon-express-mock');
+const modulesMocks = require('../../test-utilities/modules-mock');
+const expect = chai.expect;
+
+const redisClientFactoryStub = {
+  createClient: () => {
+    return modulesMocks.redisClient;
+  },
+};
+
+describe('The doppler controller', function() {
+  before(function() {
+    chai.use(sinonChai);
+  });
+
+  beforeEach(function() {
+    this.sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  it('should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
+    const request = sinonMock.mockReq({
+      session: {
+        dopplerApiKey: 'fb5d67a5bd67ab5d67ab5d'
+      },
+    });
+    const response = sinonMock.mockRes();
+    this.sandbox.stub(modulesMocks.redisClient, 'getShopsAsync').returns(
+      Promise.resolve([
+        'my-store.myshopify.com',
+        'my-store-2.myshopify.com'
+      ])
+    );
+
+    this.sandbox.stub(modulesMocks.redisClient, "getShopAsync")
+    .onCall(0)
+    .returns(
+      Promise.resolve(
+        { accessToken: "fmdklsf893rnj3nrfd", dopplerApiKey: "DSJKAHDDWAIUWDNSA", dopplerAccountName: "user1@example.com", connectedOn: "2018-11-01T01:43:06.976Z" })
+    )
+    .onCall(1)
+    .returns(
+      Promise.resolve(
+        { accessToken: "fdsf3rwefsdcsdv", dopplerApiKey: "DJKSUDAHSKJDSA", dopplerAccountName: "user2@example.com", connectedOn: "2018-10-01T01:43:06.976Z" })
+    );
+
+    const dopplerController = new DopplerController(
+      redisClientFactoryStub
+    );
+
+    await dopplerController.getShops(request, response);
+
+    expect(response.json).to.be.called.calledWithExactly([
+      { shop: 'my-store.myshopify.com', accessToken: "fmdklsf893rnj3nrfd", connectedOn: "2018-11-01T01:43:06.976Z" },
+      { shop: 'my-store-2.myshopify.com', accessToken: "fdsf3rwefsdcsdv", connectedOn: "2018-10-01T01:43:06.976Z" }
+    ]);
+
+    expect(
+      modulesMocks.redisClient.getShopsAsync
+    ).to.be.called.calledWithExactly('fb5d67a5bd67ab5d67ab5d', false);
+  });
+});

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -1,0 +1,20 @@
+module.exports = function withDoppler() {
+  return function(req, res, next) {
+    const authorizationHeader = req.get("Authorization");
+
+    if (typeof(authorizationHeader) === "undefined") {
+      res.status(401).send('Missing `Authorization` header');
+      return;
+    }
+
+    const token = authorizationHeader.substring(6);
+    if (token === "" || authorizationHeader.substring(0,5) !== "token"){
+      res.status(401).send('Invalid `Authorization` token format');
+      return;
+    }
+
+    req.session.dopplerApiKey = token;
+
+    return next();
+  };
+};

--- a/server/index.js
+++ b/server/index.js
@@ -23,9 +23,11 @@ const redisClientFactory = require('./modules/redis-client')(redis);
 
 const AppController = require('./controllers/app.controller');
 const HooksController = require('./controllers/hooks.controller');
+const DopplerController = require('./controllers/doppler.controller');
 
 const addAppRoutes = require('./routes/app');
 const addHooksRoutes = require('./routes/hooks');
+const addDopplerRoutes = require('./routes/doppler');
 
 const appController = new AppController(
   redisClientFactory,
@@ -36,6 +38,9 @@ const hooksController = new HooksController(
   redisClientFactory,
   dopplerClientFactory,
   shopifyClientFactory.shopifyAPIClientFactory
+);
+const dopplerController = new DopplerController(
+  redisClientFactory
 );
 
 const {
@@ -124,6 +129,9 @@ addAppRoutes(app, withShop, appController);
 
 // Mount Webhooks Routes
 addHooksRoutes(app, withWebhook, hooksController);
+
+// Mount Doppler Routes
+addDopplerRoutes(app, dopplerController);
 
 // Error Handlers
 app.get('/*', (req, res) => {

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -67,6 +67,16 @@ describe('Server integration tests', function() {
       .callsFake((key, obj, cb) => {
         cb();
       });
+    this.sandbox
+      .stub(mocks.wrappedRedisClient, 'sadd')
+      .callsFake((key, obj, cb) => {
+        cb();
+      });
+    this.sandbox
+      .stub(mocks.wrappedRedisClient, 'smembers')
+      .callsFake((key, cb) => {
+        cb();
+      });
     this.sandbox.stub(mocks.wrappedRedisClient, 'del').callsFake((key, cb) => {
       cb();
     });
@@ -632,6 +642,46 @@ describe('Server integration tests', function() {
     it('Should return 200 status code on success', async function() {
       await request(app)
         .post(`/hooks/doppler-import-completed?shop=${shopDomain}`)
+        .expect(function(res) {
+          expect(200).to.be.eql(res.statusCode);
+        });
+    });
+  });
+
+  describe('GET me/shops', function() {
+    it('Should return 401 status code when there is not authorization header present', async function() {
+      await request(app)
+        .get('/me/shops')
+        .expect(function(res) {
+          expect(401).to.be.eql(res.statusCode);
+          expect('Missing `Authorization` header').to.be.eql(res.text);
+        });
+    });
+
+    it('Should return 401 status code when invalid token format (1)', async function() {
+      await request(app)
+        .get('/me/shops')
+        .set('Authorization', 'INVALID HEADER')
+        .expect(function(res) {
+          expect(401).to.be.eql(res.statusCode);
+          expect('Invalid `Authorization` token format').to.be.eql(res.text);
+        });
+    });
+
+    it('Should return 401 status code when invalid token format (2)', async function() {
+      await request(app)
+        .get('/me/shops')
+        .set('Authorization', 'token')
+        .expect(function(res) {
+          expect(401).to.be.eql(res.statusCode);
+          expect('Invalid `Authorization` token format').to.be.eql(res.text);
+        });
+    });
+
+    it('Should return 200 status code when a token is passed as authorization header', async function() {
+      await request(app)
+        .get('/me/shops')
+        .set('Authorization', 'token fjdlskfjds8fu2jlskdfj')
         .expect(function(res) {
           expect(200).to.be.eql(res.statusCode);
         });

--- a/server/modules/redis-client.js
+++ b/server/modules/redis-client.js
@@ -18,12 +18,15 @@ class Redis {
       hmsetAsync: promisify(wrappedClient.hmset).bind(wrappedClient),
       delAsync: promisify(wrappedClient.del).bind(wrappedClient),
       quitAsync: promisify(wrappedClient.quit).bind(wrappedClient),
+      saddAsync: promisify(wrappedClient.sadd).bind(wrappedClient),
+      smembersAsync: promisify(wrappedClient.smembers).bind(wrappedClient)
     };
   }
 
   async storeShopAsync(shopDomain, shop, closeConnection) {
     try {
       await this.client.hmsetAsync(shopDomain, shop);
+      await this.client.saddAsync(`doppler:${shop.dopplerApiKey}`, [shopDomain]);
     } catch (error) {
       throw new Error(`Error storing shop ${shopDomain}. ${error.toString()}`);
     } finally {
@@ -45,12 +48,37 @@ class Redis {
 
   async removeShopAsync(shopDomain, closeConnection) {
     try {
+      const shop = await this.client.hgetallAsync(shopDomain);
       await this.client.delAsync(shopDomain);
+      const shops = await this.client.smembersAsync(`doppler:${shop.dopplerApiKey}`);
+      const index = shops.indexOf(shopDomain);
+      if (index > -1) {
+        shops.splice(index, 1);
+        await this.client.saddAsync(`doppler:${shop.dopplerApiKey}`, shops);
+      }
     } catch (error) {
       throw new Error(`Error removing shop ${shopDomain}. ${error.toString()}`);
     } finally {
       if (closeConnection) await this.client.quitAsync();
     }
+  }
+
+  async getShopsAsync(dopplerApiKey, closeConnection) {
+    try {
+      
+      return (await this.client.smembersAsync(`doppler:${dopplerApiKey}`)) || [];
+   
+    } catch (error) {
+      throw new Error(
+        `Error retrieving shops for Doppler account. ${error.toString()}`
+      );
+    } finally {
+      if (closeConnection) await this.client.quitAsync();
+    }
+  }
+
+  async quitAsync() {
+    await this.client.quitAsync();
   }
 }
 

--- a/server/routes/doppler/index.js
+++ b/server/routes/doppler/index.js
@@ -1,0 +1,5 @@
+const routes = require('./routes.js');
+
+module.exports = function(app, dopplerController) {
+  app.use(routes(dopplerController));
+};

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -1,0 +1,16 @@
+const Router = require('express').Router;
+const json = require('body-parser').json;
+const wrapAsync = require('../../helpers/wrapAsync');
+const withDoppler =  require('../../helpers/withDoppler');
+
+module.exports = function(dopplerController) {
+  const router = new Router();
+  router.get(
+    '/me/shops',
+    withDoppler(),
+    json(),
+    wrapAsync((req, res) => dopplerController.getShops(req, res))
+  );
+  
+  return router;
+};

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -5,12 +5,16 @@ module.exports = {
         hgetall: function(key, done){},
         del: function(key, done){},
         on: function(done){},
-        set: function(key, hset, done){}
+        set: function(key, hset, done){},
+        sadd: function(key, hset, done){},
+        smembers: function(key, done){}
     },
     redisClient: {
         getShopAsync: async function () {},
+        getShopsAsync: async function () {},
         storeShopAsync: async function () {},
-        removeShopAsync: async function () {}
+        removeShopAsync: async function () {},
+        quitAsync: async function(){}
     },
     dopplerClient: {
         AreCredentialsValidAsync: async function () {},


### PR DESCRIPTION
## Background

This PR is intendede to add the endpoint `GET /me/shops`. It uses Doppler API Key authentication and retrieves an array with all the Shopify shops associated to a Doppler account. For example:
```
[
  'my-store.myshopify.com',
  'my-store-2.myshopify.com'
]
```
The idea is that from Doppler, with the shop name and the App Secret then we can make requests to the Shopify API and retrieve abandoned checkouts, published products, etc. By doing this (instead of querying this app's API) we improve the performance, reduce the complexity, and balance the load to Shopify instead of our server.
In order to get the associated shops to a Doppler account, I have created a new entry in Redis: when connecting to Doppler, in addition to the shop, we add an entry:
KEY: dopplerApiKey
VALUE: [shop1, shop2]

## Changes done

- Added a new controller for Doppler integration, routes.
- Added unit tests, integration tests, and modified existing ones.
- Modify existing logic to use the new Redis entry
- Run tests when building with Docker

## Notes

So far, we are only retrieving the shop names, once we get the information, we're going to retrieve the details of the integration with every shop (Date of integration, number of imported subscribers, etc). This is under analysis.