### PR TITLE
Add X-Doppler-Subscriber-Origin header

### DIFF
--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -485,7 +485,7 @@ describe('Server integration tests', function() {
           {
             body: expectedRequestBody,
             method: 'POST',
-            headers: { Authorization: `token ${dopplerApiKey}` },
+            headers: { Authorization: `token ${dopplerApiKey}`, "X-Doppler-Subscriber-Origin": "Shopify" },
           }
         )
         .returns(

--- a/server/modules/doppler-client.js
+++ b/server/modules/doppler-client.js
@@ -173,7 +173,7 @@ class Doppler {
     const responseBody = await sendRequestAsync(this.fetch, url, {
       method: 'POST',
       body: JSON.stringify(subscribers),
-      headers: { Authorization: `token ${this.apiKey}` },
+      headers: { Authorization: `token ${this.apiKey}`, "X-Doppler-Subscriber-Origin": "Shopify" },
     });
 
     return responseBody.createdResourceId;
@@ -200,7 +200,7 @@ class Doppler {
     await sendRequestAsync(this.fetch, url, {
       method: 'POST',
       body: JSON.stringify(subscriber),
-      headers: { Authorization: `token ${this.apiKey}` },
+      headers: { Authorization: `token ${this.apiKey}`, "X-Doppler-Subscriber-Origin": "Shopify" },
     });
   }
 

--- a/server/modules/doppler-client.spec.js
+++ b/server/modules/doppler-client.spec.js
@@ -574,7 +574,7 @@ describe('The doppler-client module', function() {
       {
         body: expectedRequestBody,
         method: 'POST',
-        headers: { Authorization: 'token C22CADA13759DB9BBDF93B9D87C14D5A' },
+        headers: { "Authorization": 'token C22CADA13759DB9BBDF93B9D87C14D5A', "X-Doppler-Subscriber-Origin": "Shopify" },
       }
     );
   });
@@ -642,7 +642,7 @@ describe('The doppler-client module', function() {
       {
         body: expectedRequestBody,
         method: 'POST',
-        headers: { Authorization: 'token C22CADA13759DB9BBDF93B9D87C14D5A' },
+        headers: { "Authorization": 'token C22CADA13759DB9BBDF93B9D87C14D5A', "X-Doppler-Subscriber-Origin": "Shopify" },
       }
     );
   });


### PR DESCRIPTION
## Background

Just adding X-Doppler-Subscriber-Origin header when importing and creating subscribers.
We're currently setting the value *Shopify* to the header, but an improvement could be set the Shopify shop name, but it's not possible since the Doppler is not supporting any random text but a range of values.