### PR TITLE
Add extra parameters to stored shops

### DIFF
--- a/server/controllers/app.controller.spec.js
+++ b/server/controllers/app.controller.spec.js
@@ -162,6 +162,7 @@ describe('The app controller', function() {
       {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',
         dopplerAccountName: 'user@example.com',
+        synchronizedCustomersCount: 0
       },
       true
     );
@@ -443,6 +444,9 @@ describe('The app controller', function() {
         },
       ])
     );
+    this.sandbox.stub(modulesMocks.shopifyClient.customer, 'count').returns(
+      Promise.resolve(2)
+    );
     this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync').returns(
       Promise.resolve({
         accessToken: 'ae768b8c78d68a54565434',
@@ -500,8 +504,12 @@ describe('The app controller', function() {
         { shopify: 'last_name', doppler: 'LASTNAME' },
       ]
     );
+    expect(modulesMocks.redisClient.storeShopAsync).callCount(2);
+
     // TODO: mock the Date
-    //expect(modulesMocks.redisClient.storeShopAsync).to.be.calledWithExactly('store.myshopify.com', { importTaskId: 'importTask-123456' }, true);
+    expect(modulesMocks.redisClient.storeShopAsync).to.be.calledWithMatch('store.myshopify.com', { synchronizationInProgress: true }, false);
+
+    expect(modulesMocks.redisClient.storeShopAsync).to.be.calledWithExactly('store.myshopify.com', { importTaskId: 'importTask-123456', synchronizedCustomersCount: 2 }, true);
     expect(response.sendStatus).to.be.called.calledWithExactly(201);
   });
 

--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -13,9 +13,14 @@ class DopplerController {
         .map(async shopName => {
             let shop = await redis.getShopAsync(shopName);
             return {
-                shop: shopName,
-                accessToken: shop.accessToken,
-                connectedOn: shop.connectedOn
+                shopName: shopName,
+                shopifyAccessToken: shop.accessToken,
+                connectedOn: shop.connectedOn,
+                dopplerListId: shop.dopplerListId,
+                importedCustomersCount: shop.synchronizedCustomersCount,
+                syncProcessDopplerImportSubscribersTaskId: shop.importTaskId,
+                syncProcessInProgress: shop.synchronizationInProgress,
+                syncProcessLastRunDate: shop.lastSynchronizationDate
             };
         });
         

--- a/server/controllers/doppler.controller.spec.js
+++ b/server/controllers/doppler.controller.spec.js
@@ -43,12 +43,12 @@ describe('The doppler controller', function() {
     .onCall(0)
     .returns(
       Promise.resolve(
-        { accessToken: "fmdklsf893rnj3nrfd", dopplerApiKey: "DSJKAHDDWAIUWDNSA", dopplerAccountName: "user1@example.com", connectedOn: "2018-11-01T01:43:06.976Z" })
+        { accessToken: "fmdklsf893rnj3nrfd", lastSynchronizationDate: "2018-11-01T01:43:05.976Z", connectedOn: "2018-11-01T01:43:06.976Z", dopplerListId: 321, synchronizationInProgress: false, synchronizedCustomersCount: 33, importTaskId: "task-321" })
     )
     .onCall(1)
     .returns(
       Promise.resolve(
-        { accessToken: "fdsf3rwefsdcsdv", dopplerApiKey: "DJKSUDAHSKJDSA", dopplerAccountName: "user2@example.com", connectedOn: "2018-10-01T01:43:06.976Z" })
+        { accessToken: "fdsf3rwefsdcsdv", lastSynchronizationDate: "2018-11-01T01:43:05.976Z", connectedOn: "2018-10-01T01:43:06.976Z", dopplerListId: 123, synchronizationInProgress: true, synchronizedCustomersCount: 0, importTaskId: undefined })
     );
 
     const dopplerController = new DopplerController(
@@ -58,8 +58,26 @@ describe('The doppler controller', function() {
     await dopplerController.getShops(request, response);
 
     expect(response.json).to.be.called.calledWithExactly([
-      { shop: 'my-store.myshopify.com', accessToken: "fmdklsf893rnj3nrfd", connectedOn: "2018-11-01T01:43:06.976Z" },
-      { shop: 'my-store-2.myshopify.com', accessToken: "fdsf3rwefsdcsdv", connectedOn: "2018-10-01T01:43:06.976Z" }
+      { 
+        shopName: "my-store.myshopify.com", 
+        shopifyAccessToken: "fmdklsf893rnj3nrfd", 
+        connectedOn: "2018-11-01T01:43:06.976Z", 
+        dopplerListId: 321, 
+        syncProcessInProgress: false, 
+        importedCustomersCount: 33, 
+        syncProcessDopplerImportSubscribersTaskId: "task-321",
+        syncProcessLastRunDate:  "2018-11-01T01:43:05.976Z"
+      },
+      { 
+        shopName: "my-store-2.myshopify.com", 
+        shopifyAccessToken: "fdsf3rwefsdcsdv", 
+        connectedOn: "2018-10-01T01:43:06.976Z", 
+        dopplerListId: 123, 
+        syncProcessInProgress: true,
+        importedCustomersCount: 0, 
+        syncProcessDopplerImportSubscribersTaskId: undefined,
+        syncProcessLastRunDate:  "2018-11-01T01:43:05.976Z"
+      }
     ]);
 
     expect(

--- a/server/controllers/hooks.controller.js
+++ b/server/controllers/hooks.controller.js
@@ -28,28 +28,30 @@ class HooksController {
     try
     {
       const redis = this.redisClientFactory.createClient();
-      const shopInstance = await redis.getShopAsync(
-        request.webhook.shopDomain,
-        true
-      );
+      const shopInstance = await redis.getShopAsync(request.webhook.shopDomain, false);
 
       if (
         !shopInstance ||
         !shopInstance.dopplerListId ||
         !shopInstance.fieldsMapping
       )
+      {
+        await redis.quitAsync();
         return;
+      }
 
       const customer = JSON.parse(request.body);
-      const doppler = this.dopplerClientFactory.createClient(
-        shopInstance.dopplerAccountName,
-        shopInstance.dopplerApiKey
-      );
+      const doppler = this.dopplerClientFactory.createClient(shopInstance.dopplerAccountName, shopInstance.dopplerApiKey);
+      
       await doppler.createSubscriberAsync(
         customer,
         shopInstance.dopplerListId,
         JSON.parse(shopInstance.fieldsMapping)
       );
+
+      shopInstance.synchronizedCustomersCount = (parseInt(shopInstance.synchronizedCustomersCount) || 0) + 1;
+
+      await redis.storeShopAsync(request.webhook.shopDomain, shopInstance, true);
     }
     catch(err){}
   }

--- a/server/modules/shopify-extras.js
+++ b/server/modules/shopify-extras.js
@@ -205,4 +205,5 @@ module.exports = {
     },
   ],
   shopifyAPIClientFactory: new ShopifyAPIClientFactory(),
+  shopifyCustomersPageSize: 250 // 250 = MAX
 };

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -29,7 +29,8 @@ module.exports = {
             create: async function () {}
         },
         customer: {
-            list: async function () {}
+            list: async function () {},
+            count: async function () {}
         }
     }
 }


### PR DESCRIPTION
## Background

Well, there are several changes in this PR.
In first place when retrieving the shops for a given Doppler account, now we're returning all the data associated to it.
Another change is to add a counter to with the imported subscribers. When running the synchronization process the counter is reset, on the other hand, when creating a new subscriber (webhook when a customer is created), we increase the counter.

Finally I fixed a pagination issue that we had when retrieving the customers from Shopify: the endpoint returns a page so if we had more customers than the default page size  (50), we were only retrieving 50, now we iterate over the totality of the customers when running the syncrhonization process.