### PR TITLE
[DBR-16803] Accept JWT Token in `GET /me/shops`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "global": "^4.4.0",
     "mocha": "^5.2.0",
+    "node-mocks-http": "^1.7.6",
     "nyc": "^14.1.1",
     "postcss-loader": "^3.0.0",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "file-loader": "^4.1.0",
+    "jsonwebtoken": "^8.5.1",
     "knex": "^0.19.0",
     "morgan": "^1.9.1",
     "nodemon": "^1.19.1",

--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -4,13 +4,9 @@ class DopplerController {
       this.appController = appController;
     }
 
-    async getShops(request, response) {
-        const {
-          dopplerData: { apiKey }
-        } = request;
-
+    async getShops({ dopplerData }, response) {
         const redis = this.redisClientFactory.createClient();
-        const shops = (await redis.getAllShopDomainsByDopplerApiKeyAsync(apiKey, false))
+        const shops = (await redis.getAllShopDomainsByDopplerDataAsync(dopplerData, false))
         .map(async shopName => {
             let shop = await redis.getShopAsync(shopName);
             return {

--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -10,7 +10,7 @@ class DopplerController {
         } = request;
 
         const redis = this.redisClientFactory.createClient();
-        const shops = (await redis.getShopsAsync(apiKey, false))
+        const shops = (await redis.getAllShopDomainsByDopplerApiKeyAsync(apiKey, false))
         .map(async shopName => {
             let shop = await redis.getShopAsync(shopName);
             return {

--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -6,11 +6,11 @@ class DopplerController {
 
     async getShops(request, response) {
         const {
-            session: { dopplerApiKey }
+          dopplerData: { apiKey }
         } = request;
 
         const redis = this.redisClientFactory.createClient();
-        const shops = (await redis.getShopsAsync(dopplerApiKey, false))
+        const shops = (await redis.getShopsAsync(apiKey, false))
         .map(async shopName => {
             let shop = await redis.getShopAsync(shopName);
             return {
@@ -29,11 +29,11 @@ class DopplerController {
         await redis.quitAsync();
     }
 
-    async synchronizeCustomers({ query: { force }, session: { dopplerApiKey }, body: { shop } }, response) {
+    async synchronizeCustomers({ query: { force }, dopplerData: { apiKey }, body: { shop } }, response) {
       const redis = this.redisClientFactory.createClient();
       const shopInstance = await redis.getShopAsync(shop);
 
-      if (dopplerApiKey != shopInstance.dopplerApiKey) {
+      if (apiKey != shopInstance.dopplerApiKey) {
           response.sendStatus(403);
           return;
       }

--- a/server/controllers/doppler.controller.spec.js
+++ b/server/controllers/doppler.controller.spec.js
@@ -25,14 +25,14 @@ describe('The doppler controller', function() {
     this.sandbox.restore();
   });
 
-  it('getAllShopDomainsByDopplerApiKeyAsync should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
+  it('getShops should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
     const request = sinonMock.mockReq({
       dopplerData: {
         apiKey: 'fb5d67a5bd67ab5d67ab5d'
       },
     });
     const response = sinonMock.mockRes();
-    this.sandbox.stub(modulesMocks.redisClient, 'getAllShopDomainsByDopplerApiKeyAsync').returns(
+    this.sandbox.stub(modulesMocks.redisClient, 'getAllShopDomainsByDopplerDataAsync').returns(
       Promise.resolve([
         'my-store.myshopify.com',
         'my-store-2.myshopify.com'
@@ -82,8 +82,8 @@ describe('The doppler controller', function() {
     ]);
 
     expect(
-      modulesMocks.redisClient.getAllShopDomainsByDopplerApiKeyAsync
-    ).to.be.called.calledWithExactly('fb5d67a5bd67ab5d67ab5d', false);
+      modulesMocks.redisClient.getAllShopDomainsByDopplerDataAsync
+    ).to.be.called.calledWithExactly({ apiKey: 'fb5d67a5bd67ab5d67ab5d' }, false);
   });
 
   it('synchronizeCustomers should synchronize customers using compossed controller', async function() {

--- a/server/controllers/doppler.controller.spec.js
+++ b/server/controllers/doppler.controller.spec.js
@@ -27,8 +27,8 @@ describe('The doppler controller', function() {
 
   it('getShops should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
     const request = sinonMock.mockReq({
-      session: {
-        dopplerApiKey: 'fb5d67a5bd67ab5d67ab5d'
+      dopplerData: {
+        apiKey: 'fb5d67a5bd67ab5d67ab5d'
       },
     });
     const response = sinonMock.mockRes();
@@ -89,7 +89,7 @@ describe('The doppler controller', function() {
   it('synchronizeCustomers should synchronize customers using compossed controller', async function() {
     const request = sinonMock.mockReq({
       body: { shop: "my-store.myshopify.com" },
-      session: { dopplerApiKey: 'fb5d67a5bd67ab5d67ab5d' }
+      dopplerData: { apiKey: 'fb5d67a5bd67ab5d67ab5d' }
     });
     const response = sinonMock.mockRes();
 
@@ -116,7 +116,7 @@ describe('The doppler controller', function() {
     // Arrange
     const request = sinonMock.mockReq({
       body: { shop: "my-store.myshopify.com" },
-      session: { dopplerApiKey: 'fb5d67a5bd67ab5d67ab5d' }
+      dopplerData: { apiKey: 'fb5d67a5bd67ab5d67ab5d' }
     });
     const response = sinonMock.mockRes();
 

--- a/server/controllers/doppler.controller.spec.js
+++ b/server/controllers/doppler.controller.spec.js
@@ -25,14 +25,14 @@ describe('The doppler controller', function() {
     this.sandbox.restore();
   });
 
-  it('getShops should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
+  it('getAllShopDomainsByDopplerApiKeyAsync should return a list of N shops when there are N shops associated to the same Doppler account', async function() {
     const request = sinonMock.mockReq({
       dopplerData: {
         apiKey: 'fb5d67a5bd67ab5d67ab5d'
       },
     });
     const response = sinonMock.mockRes();
-    this.sandbox.stub(modulesMocks.redisClient, 'getShopsAsync').returns(
+    this.sandbox.stub(modulesMocks.redisClient, 'getAllShopDomainsByDopplerApiKeyAsync').returns(
       Promise.resolve([
         'my-store.myshopify.com',
         'my-store-2.myshopify.com'
@@ -82,7 +82,7 @@ describe('The doppler controller', function() {
     ]);
 
     expect(
-      modulesMocks.redisClient.getShopsAsync
+      modulesMocks.redisClient.getAllShopDomainsByDopplerApiKeyAsync
     ).to.be.called.calledWithExactly('fb5d67a5bd67ab5d67ab5d', false);
   });
 

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -17,6 +17,10 @@ module.exports = function withDoppler() {
       // DOPPLER API KEY
       req.dopplerData = { apiKey: token };
       return next();
+    } else if (/^ey[\w-]+\.ey[\w-]+\.[\w-]+$/.test(token)) {
+      // JWT TOKEN
+      req.dopplerData = { tokenJwt: token };
+      return next();
     }
     
     res.status(401).send('Invalid `Authorization` token format. Expected a Doppler API Key or a Doppler JWT Token.');

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -15,9 +15,9 @@ module.exports = function withDoppler() {
 
     if (/^[ABCDEF\d]{32}$/i.test(token)) {
       // DOPPLER API KEY
-      req.session.dopplerApiKey = token;
+      req.dopplerData = { apiKey: token };
       return next();
-    } 
+    }
     
     res.status(401).send('Invalid `Authorization` token format. Expected a Doppler API Key or a Doppler JWT Token.');
   };

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -9,12 +9,16 @@ module.exports = function withDoppler() {
 
     const token = authorizationHeader.substring(6);
     if (token === "" || authorizationHeader.substring(0,5) !== "token"){
-      res.status(401).send('Invalid `Authorization` token format');
+      res.status(401).send('Invalid `Authorization` token format. It should be something like: `Authorization: token {DopplerApiKey/DopplerJwtToken}`.');
       return;
     }
 
-    req.session.dopplerApiKey = token;
-
-    return next();
+    if (/^[ABCDEF\d]{32}$/i.test(token)) {
+      // DOPPLER API KEY
+      req.session.dopplerApiKey = token;
+      return next();
+    } 
+    
+    res.status(401).send('Invalid `Authorization` token format. Expected a Doppler API Key or a Doppler JWT Token.');
   };
 };

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -33,6 +33,9 @@ function withDoppler(configuration) {
       return;
     }
 
+    // TODO: Parse accountName from `/doppler/{accountName}/...` routes
+    // and inject it in DopplerData.
+
     if (/^[ABCDEF\d]{32}$/i.test(token)) {
       // DOPPLER API KEY
       req.dopplerData = { apiKey: token };
@@ -44,6 +47,7 @@ function withDoppler(configuration) {
           res.status(401).send(`Invalid \`Authorization\` token. JWT Error: ${err.message}`);
           return;
         } else {
+          // TODO: validate that decoded.sub matches accountName from the URL or isSuperUser
           req.dopplerData = { 
             tokenJwt: token,
             accountName: decoded.sub,

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -8,7 +8,7 @@ module.exports = function withDoppler() {
     }
 
     const token = authorizationHeader.substring(6);
-    if (token === "" || authorizationHeader.substring(0,5) !== "token"){
+    if (!token || authorizationHeader.substring(0,5) !== "token"){
       res.status(401).send('Invalid `Authorization` token format. It should be something like: `Authorization: token {DopplerApiKey/DopplerJwtToken}`.');
       return;
     }

--- a/server/helpers/withDoppler.spec.js
+++ b/server/helpers/withDoppler.spec.js
@@ -1,0 +1,112 @@
+const sinon = require('sinon');
+const chai = require('chai');
+const httpMocks = require('node-mocks-http');
+const expect = chai.expect;
+const withDoppler = require('./withDoppler');
+
+
+describe('withDoppler middleware', () => {
+  it('should return 401 error when there is not an authorization header', () => {
+    // Arrange
+    const middleware = withDoppler();
+    const req = httpMocks.createRequest();
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(res.statusCode).to.be.equal(401);
+    expect(res._getData()).to.be.equal('Missing `Authorization` header');
+    expect(next.notCalled).to.be.true;
+  });
+
+  it('should return 401 error when there is an authorization header without `token`', () => {
+    // Arrange
+    const middleware = withDoppler();
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: 'bearer AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' 
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(res.statusCode).to.be.equal(401);
+    expect(res._getData()).to.be.equal(
+      'Invalid `Authorization` token format. It should be something like: `Authorization: token {DopplerApiKey/DopplerJwtToken}`.');
+    expect(next.notCalled).to.be.true;
+  });
+
+  it('should return 401 error when there is an authorization with `token` with an unexpected format', () => {
+    // Arrange
+    const middleware = withDoppler();
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: 'token 0123456789ABCDEF'
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(res.statusCode).to.be.equal(401);
+    expect(res._getData()).to.be.equal(
+      'Invalid `Authorization` token format. Expected a Doppler API Key or a Doppler JWT Token.');
+    expect(next.notCalled).to.be.true;
+  });
+
+  it('should fill dopplerData.apiKey when token has an APIKEY format', () => {
+    // Arrange
+    const middleware = withDoppler();
+    const token = '0123456789ABCDEF0123456789ABCDEF';
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: `token ${token}`
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(next.calledOnce).to.be.true;
+    expect(req).to.have.property('dopplerData');
+    expect(req.dopplerData).to.have.property('apiKey');
+    expect(req.dopplerData).to.not.have.property('tokenJwt');
+    expect(req.dopplerData.apiKey).to.equal(token);
+  });
+
+  it('should fill dopplerData.tokenJwt when token has an JWT format', () => {
+    // Arrange
+    const middleware = withDoppler();
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: `token ${token}`
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(next.calledOnce).to.be.true;
+    expect(req).to.have.property('dopplerData');
+    expect(req.dopplerData).to.have.property('tokenJwt');
+    expect(req.dopplerData).to.not.have.property('apiKey');
+    expect(req.dopplerData.tokenJwt).to.equal(token);
+  });
+});

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -64,20 +64,20 @@ describe('Server integration tests', function() {
     });
     this.sandbox
       .stub(mocks.wrappedRedisClient, 'hmset')
-      .callsFake((key, obj, cb) => {
+      .callsFake((_key, _obj, cb) => {
         cb();
       });
     this.sandbox
       .stub(mocks.wrappedRedisClient, 'sadd')
-      .callsFake((key, obj, cb) => {
+      .callsFake((_key, _obj, cb) => {
         cb();
       });
     this.sandbox
       .stub(mocks.wrappedRedisClient, 'smembers')
-      .callsFake((key, cb) => {
+      .callsFake((_key, cb) => {
         cb();
       });
-    this.sandbox.stub(mocks.wrappedRedisClient, 'del').callsFake((key, cb) => {
+    this.sandbox.stub(mocks.wrappedRedisClient, 'del').callsFake((_key, cb) => {
       cb();
     });
   });
@@ -90,7 +90,7 @@ describe('Server integration tests', function() {
     await request(app)
       .get(`/foo/bar`)
       .expect(function(res) {
-        expect(302).to.be.eql(res.statusCode);
+        expect(res.statusCode).to.be.eql(302);
       });
   });
 
@@ -141,7 +141,7 @@ describe('Server integration tests', function() {
           expect(res.statusCode).to.be.eql(302);
           expect(res.headers.location).to.be.eql('/');
           cookie = res.get('set-cookie');
-          expect(1).to.be.eql(cookie.length);
+          expect(cookie.length).to.be.eql(1);
         });
     });
   });
@@ -170,7 +170,7 @@ describe('Server integration tests', function() {
     it('Should render the home page when there is an existing session', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, {
             accessToken: accessToken,
             dopplerAccountName: dopplerAccountName,
@@ -181,14 +181,14 @@ describe('Server integration tests', function() {
         .get('/')
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
 
     it('Should redirect to /shopify/auth?shop={shop} when access token has changed', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, {
             accessToken: '111111111111',
             dopplerAccountName: dopplerAccountName,
@@ -199,7 +199,7 @@ describe('Server integration tests', function() {
         .get('/')
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(302).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(302);
           expect(res.headers.location).to.be.eql(
             `/shopify/auth?shop=${shopDomain}`
           );
@@ -232,7 +232,7 @@ describe('Server integration tests', function() {
         .send({ dopplerAccountName, dopplerApiKey: 'AAAAAAAAAAAAAAAAAA' })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(401);
         });
     });
 
@@ -260,7 +260,7 @@ describe('Server integration tests', function() {
         .send({ dopplerAccountName, dopplerApiKey })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
 
@@ -281,7 +281,7 @@ describe('Server integration tests', function() {
         .send({ dopplerAccountName, dopplerApiKey })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(500).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(500);
         });
     });
   });
@@ -290,7 +290,7 @@ describe('Server integration tests', function() {
     it('Should return the Doppler lists correctly', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken, dopplerAccountName, dopplerApiKey, dopplerListId });
         });
 
@@ -316,9 +316,8 @@ describe('Server integration tests', function() {
         .get('/doppler-lists')
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(
-            '{"items":[{"listId":1459381,"name":"shopify"},{"listId":1222381,"name":"marketing"},{"listId":1170501,"name":"development"}],"itemsCount":3}'
-          ).to.be.eql(res.text);
+          expect(res.text).to.be.eql(
+            '{"items":[{"listId":1459381,"name":"shopify"},{"listId":1222381,"name":"marketing"},{"listId":1170501,"name":"development"}],"itemsCount":3}');
           expect(200).to.be.eql(res.statusCode);
         });
     });
@@ -326,7 +325,7 @@ describe('Server integration tests', function() {
     it('Should return 500 status code when there is not a Doppler API key', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken });
         });
 
@@ -334,7 +333,7 @@ describe('Server integration tests', function() {
         .get('/doppler-lists')
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(500).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(500);
         });
     });
   });
@@ -363,7 +362,7 @@ describe('Server integration tests', function() {
 
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken, dopplerAccountName, dopplerApiKey });
         });
 
@@ -373,14 +372,14 @@ describe('Server integration tests', function() {
         .set('cookie', cookie)
         .expect(function(res) {
           expect(res.body).to.be.eql({ listId: '1462409' });
-          expect(201).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(201);
         });
     });
 
     it('Should return 500 status code when there is not a Doppler API key', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken });
         });
 
@@ -389,7 +388,7 @@ describe('Server integration tests', function() {
         .send({ name: 'Fresh List' })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(500).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(500);
         });
     });
   });
@@ -401,7 +400,7 @@ describe('Server integration tests', function() {
         .send({ dopplerListId })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -426,7 +425,7 @@ describe('Server integration tests', function() {
 
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken, dopplerAccountName, dopplerApiKey });
         });
 
@@ -435,7 +434,7 @@ describe('Server integration tests', function() {
         .set('cookie', cookie)
         .expect(function(res) {
           expect(res.text.length).to.be.gt(0);
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -453,7 +452,7 @@ describe('Server integration tests', function() {
         })
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -462,7 +461,7 @@ describe('Server integration tests', function() {
     it('Should return 201 status code on success', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, {
             shop: shopDomain,
             accessToken,
@@ -529,7 +528,7 @@ describe('Server integration tests', function() {
         .post('/synchronize-customers')
         .set('cookie', cookie)
         .expect(function(res) {
-          expect(201).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(201);
         });
     });
   });
@@ -542,21 +541,16 @@ describe('Server integration tests', function() {
         .set('X-Shopify-Topic', 'app/uninstalled')
         .set('X-Shopify-Shop-Domain', shopDomain)
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(401);
         });
     });
 
     it('Should return 401 status code when shop does not exist', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, null);
         });
-
-      const hmac = crypto
-        .createHmac('sha256', process.env.SHOPIFY_APP_SECRET)
-        .update(new Buffer([]))
-        .digest('base64');
 
       await request(app)
         .post('/hooks/app/uninstalled')
@@ -564,14 +558,14 @@ describe('Server integration tests', function() {
         .set('X-Shopify-Topic', 'app/uninstalled')
         .set('X-Shopify-Shop-Domain', shopDomain)
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(401);
         });
     });
 
     it('Should return 200 status code on success', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, { accessToken });
         });
 
@@ -586,7 +580,7 @@ describe('Server integration tests', function() {
         .set('X-Shopify-Topic', 'app/uninstalled')
         .set('X-Shopify-Shop-Domain', shopDomain)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -595,7 +589,7 @@ describe('Server integration tests', function() {
     it('Should return 200 status code on success', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, {
             shop: shopDomain,
             accessToken,
@@ -633,7 +627,7 @@ describe('Server integration tests', function() {
           '{"id":623558295613,"email":"jonsnow@example.com","first_name":"Jon","last_name":"Snow","default_address":{"company":"Winterfell"}}'
         )
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -643,7 +637,7 @@ describe('Server integration tests', function() {
       await request(app)
         .post(`/hooks/doppler-import-completed?shop=${shopDomain}`)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -653,7 +647,7 @@ describe('Server integration tests', function() {
       await request(app)
         .get('/me/shops')
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(401);
           expect('Missing `Authorization` header').to.be.eql(res.text);
         });
     });
@@ -663,8 +657,8 @@ describe('Server integration tests', function() {
         .get('/me/shops')
         .set('Authorization', 'INVALID HEADER')
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
-          expect('Invalid `Authorization` token format').to.be.eql(res.text);
+          expect(res.statusCode).to.be.eql(401);
+          expect(res.text).to.be.eql('Invalid `Authorization` token format');
         });
     });
 
@@ -673,17 +667,17 @@ describe('Server integration tests', function() {
         .get('/me/shops')
         .set('Authorization', 'token')
         .expect(function(res) {
-          expect(401).to.be.eql(res.statusCode);
-          expect('Invalid `Authorization` token format').to.be.eql(res.text);
+          expect(res.statusCode).to.be.eql(401);
+          expect(res.text).to.be.eql('Invalid `Authorization` token format');
         });
     });
-
+    
     it('Should return 200 status code when a token is passed as authorization header', async function() {
       await request(app)
         .get('/me/shops')
-        .set('Authorization', 'token fjdlskfjds8fu2jlskdfj')
+        .set('Authorization', `token ${dopplerApiKey}`)
         .expect(function(res) {
-          expect(200).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(200);
         });
     });
   });
@@ -692,7 +686,7 @@ describe('Server integration tests', function() {
     it('Should return 201 status code on success', async function() {
       this.sandbox
         .stub(mocks.wrappedRedisClient, 'hgetall')
-        .callsFake((key, cb) => {
+        .callsFake((_key, cb) => {
           cb(null, {
             shop: shopDomain,
             accessToken,
@@ -760,7 +754,7 @@ describe('Server integration tests', function() {
         .set('Authorization', `token ${dopplerApiKey}`)
         .send({ shop: shopDomain })
         .expect(function(res) {
-          expect(201).to.be.eql(res.statusCode);
+          expect(res.statusCode).to.be.eql(201);
         });
     });
   });

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -658,7 +658,7 @@ describe('Server integration tests', function() {
         .set('Authorization', 'INVALID HEADER')
         .expect(function(res) {
           expect(res.statusCode).to.be.eql(401);
-          expect(res.text).to.be.eql('Invalid `Authorization` token format');
+          expect(res.text).to.be.eql('Invalid `Authorization` token format. It should be something like: `Authorization: token {DopplerApiKey/DopplerJwtToken}`.');
         });
     });
 
@@ -668,7 +668,17 @@ describe('Server integration tests', function() {
         .set('Authorization', 'token')
         .expect(function(res) {
           expect(res.statusCode).to.be.eql(401);
-          expect(res.text).to.be.eql('Invalid `Authorization` token format');
+          expect(res.text).to.be.eql('Invalid `Authorization` token format. It should be something like: `Authorization: token {DopplerApiKey/DopplerJwtToken}`.');
+        });
+    });
+
+    it('Should return 401 status code when invalid token format (APIKEY without a character)', async function() {
+      await request(app)
+        .get('/me/shops')
+        .set('Authorization', `token ${dopplerApiKey.substring(0, 31)}`)
+        .expect(function(res) {
+          expect(res.statusCode).to.be.eql(401);
+          expect(res.text).to.be.eql('Invalid `Authorization` token format. Expected a Doppler API Key or a Doppler JWT Token.');
         });
     });
     

--- a/server/modules/redis-client.js
+++ b/server/modules/redis-client.js
@@ -93,13 +93,6 @@ class Redis {
     }
   }
 
-  /**
-   * @deprecated use getAllShopDomainsByDopplerApiKey or getAllShopDomainsByDopplerAccountName in place
-   */
-  async getShopsAsync(dopplerApiKey, closeConnection) {
-    return await this.getAllShopDomainsByDopplerApiKeyAsync(dopplerApiKey, closeConnection);
-  }
-
   async getAllShopDomainsByDopplerApiKeyAsync(dopplerApiKey, closeConnection) {
     try {
       const newShops = (await this.client.smembersAsync(keyShopDomainsByDopplerApikey({dopplerApiKey}))) || [];

--- a/server/modules/redis-client.js
+++ b/server/modules/redis-client.js
@@ -93,6 +93,11 @@ class Redis {
     }
   }
 
+  async getAllShopDomainsByDopplerDataAsync(dopplerData, closeConnection) {
+    return dopplerData.accountName ? (await this.getAllShopDomainsByDopplerAccountNameAsync(dopplerData.accountName, closeConnection))
+      : (await this.getAllShopDomainsByDopplerApiKeyAsync(dopplerData.apiKey, closeConnection));
+  }
+
   async getAllShopDomainsByDopplerApiKeyAsync(dopplerApiKey, closeConnection) {
     try {
       const newShops = (await this.client.smembersAsync(keyShopDomainsByDopplerApikey({dopplerApiKey}))) || [];

--- a/server/modules/redis-client.spec.js
+++ b/server/modules/redis-client.spec.js
@@ -583,4 +583,34 @@ describe('The redis-client module', function() {
     }, `Error retrieving shops for Doppler account. Error: ${errorMessage}`);
   });
   
+  it(`getAllShopDomainsByDopplerDataAsync should search by shopDomainsByDopplerAccountName when dopplerData has accountName field`, async function() {
+    const accountName = 'email@test.com';
+    const domain = 'domain.com';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (key, cb) => { cb(
+        undefined, 
+        key === `shopDomainsByDopplerAccountName:${accountName}` ? [ domain ] : null); }
+    });
+    const redisClient = Redis.createClient();
+    const result = await redisClient.getAllShopDomainsByDopplerDataAsync({ accountName });
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(1);
+    expect(result).to.be.deep.equal([ domain ]);
+  });
+
+  it(`getAllShopDomainsByDopplerDataAsync should search by shopDomainsByDopplerApikey when dopplerData has apiKey field`, async function() {
+    const apiKey = '0123456789ABCDEF';
+    const domain1 = 'domain1.com';
+    const domain2 = 'domain2.com';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (key, cb) => { cb(
+        undefined, 
+        key === `shopDomainsByDopplerApikey:${apiKey}` ? [ domain1 ] 
+        : key === `doppler:${apiKey}` ? [ domain2 ] 
+        : null); }
+    });
+    const redisClient = Redis.createClient();
+    const result = await redisClient.getAllShopDomainsByDopplerDataAsync({ apiKey });
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(2);
+    expect(result).to.be.deep.equal([ domain1, domain2 ]);
+  });
 });

--- a/server/modules/redis-client.spec.js
+++ b/server/modules/redis-client.spec.js
@@ -411,116 +411,112 @@ describe('The redis-client module', function() {
     expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(1);
   });
 
-  // getShopsAsync is deprecated
-  const getAllShopDomainsByDopplerApiKeyAliases = ['getShopsAsync', 'getAllShopDomainsByDopplerApiKeyAsync'];
-  for (const alias of getAllShopDomainsByDopplerApiKeyAliases) {
-    it(`${alias} should not call quit when flag is not set`, async function() {
-      prepareDummySandbox(this.sandbox);
-      const redisClient = Redis.createClient();
-      await redisClient[alias]('dhnsa789dhsaiffdsfds');
-      expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(0);
+  it('getAllShopDomainsByDopplerApiKeyAsync should not call quit when flag is not set', async function() {
+    prepareDummySandbox(this.sandbox);
+    const redisClient = Redis.createClient();
+    await redisClient.getAllShopDomainsByDopplerApiKeyAsync('dhnsa789dhsaiffdsfds');
+    expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(0);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should call quit when flag is set', async function() {
+    prepareDummySandbox(this.sandbox);
+    const redisClient = Redis.createClient();
+    await redisClient.getAllShopDomainsByDopplerApiKeyAsync('dhnsa789dhsaiffdsfds', true);
+    expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(1);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should call wrapped method correctly', async function() {
+    prepareDummySandbox(this.sandbox);
+    const redisClient = Redis.createClient();
+    await redisClient.getAllShopDomainsByDopplerApiKeyAsync('dhnsa789dhsaiffdsfds');
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(2);
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
+      'shopDomainsByDopplerApikey:dhnsa789dhsaiffdsfds'
+    );
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
+      'doppler:dhnsa789dhsaiffdsfds'
+    );
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should return a two elements array when there are two shops for a given Doppler API key', async function() {
+    const requestKey = 'dhnsa789dhsaiffdsfds';
+    const domain1 = 'dominio1.com';
+    const domain2 = 'dominio2.com';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (key, cb) => { cb(
+        undefined, 
+        key === `shopDomainsByDopplerApikey:${requestKey}` ? [domain1, domain2]
+          : key.startsWith('doppler:') ? null
+          : 'dominio3.com'
+        ); }
+    });
+    const redisClient = Redis.createClient();
+    var result = await redisClient.getAllShopDomainsByDopplerApiKeyAsync(requestKey, true);
+    expect(result).to.be.eql([domain1, domain2]);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should return shop domains with new and old key format', async function() {
+    const requestKey = 'dhnsa789dhsaiffdsfds';
+    const domain1 = 'dominio1.com';
+    const domain2 = 'dominio2.com';
+    const domain3 = 'dominio3.com';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (key, cb) => { cb(
+        undefined, 
+        key === `shopDomainsByDopplerApikey:${requestKey}` ? [domain1, domain2] 
+        : key === `doppler:${requestKey}` ? [domain3] 
+        : 'dominio4.com'
+        ); }
+    });
+    const redisClient = Redis.createClient();
+    var result = await redisClient.getAllShopDomainsByDopplerApiKeyAsync(requestKey, true);
+    expect(result).to.be.eql([domain1, domain2, domain3]);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should return a two elements array when there are two shops for a given Doppler API key in old format', async function() {
+    const requestKey = 'dhnsa789dhsaiffdsfds';
+    const domain1 = 'dominio1.com';
+    const domain2 = 'dominio2.com';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (key, cb) => { cb(
+        undefined, 
+        key.startsWith('shopDomainsByDopplerApikey:') ? null
+          : key === `doppler:${requestKey}` ? [domain1, domain2]
+          : 'dominio3.com'
+        ); }
+    });
+    const redisClient = Redis.createClient();
+    var result = await redisClient.getAllShopDomainsByDopplerApiKeyAsync(requestKey, true);
+    expect(result).to.be.eql([domain1, domain2]);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should return an empty array when shops do not exist for a given Doppler API key', async function() {
+    prepareDummySandbox(this.sandbox);
+    const redisClient = Redis.createClient();
+    var result = await redisClient.getAllShopDomainsByDopplerApiKeyAsync('dhnsa789dhsaiffdsfds', true);
+    expect(result).to.be.eql([]);
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(2);
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
+      'shopDomainsByDopplerApikey:dhnsa789dhsaiffdsfds'
+    );
+    expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
+      'doppler:dhnsa789dhsaiffdsfds'
+    );
+    expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(1);
+  });
+
+  it('getAllShopDomainsByDopplerApiKeyAsync should raise the error thrown by redis', async function() {
+    const errorMessage = 'Forced Error';
+    prepareDummySandbox(this.sandbox, {
+      smembers: (_key, cb) => { cb(new Error(errorMessage)); }
     });
 
-    it(`${alias} should call quit when flag is set`, async function() {
-      prepareDummySandbox(this.sandbox);
-      const redisClient = Redis.createClient();
-      await redisClient[alias]('dhnsa789dhsaiffdsfds', true);
-      expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(1);
-    });
+    const redisClient = Redis.createClient();
 
-    it(`${alias} should call wrapped method correctly`, async function() {
-      prepareDummySandbox(this.sandbox);
-      const redisClient = Redis.createClient();
-      await redisClient[alias]('dhnsa789dhsaiffdsfds');
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(2);
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
-        'shopDomainsByDopplerApikey:dhnsa789dhsaiffdsfds'
-      );
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
-        'doppler:dhnsa789dhsaiffdsfds'
-      );
-    });
-
-    it(`${alias} should return a two elements array when there are two shops for a given Doppler API key`, async function() {
-      const requestKey = 'dhnsa789dhsaiffdsfds';
-      const domain1 = 'dominio1.com';
-      const domain2 = 'dominio2.com';
-      prepareDummySandbox(this.sandbox, {
-        smembers: (key, cb) => { cb(
-          undefined, 
-          key === `shopDomainsByDopplerApikey:${requestKey}` ? [domain1, domain2]
-            : key.startsWith('doppler:') ? null
-            : 'dominio3.com'
-          ); }
-      });
-      const redisClient = Redis.createClient();
-      var result = await redisClient[alias](requestKey, true);
-      expect(result).to.be.eql([domain1, domain2]);
-    });
-
-    it(`${alias} should return shop domains with new and old key format`, async function() {
-      const requestKey = 'dhnsa789dhsaiffdsfds';
-      const domain1 = 'dominio1.com';
-      const domain2 = 'dominio2.com';
-      const domain3 = 'dominio3.com';
-      prepareDummySandbox(this.sandbox, {
-        smembers: (key, cb) => { cb(
-          undefined, 
-          key === `shopDomainsByDopplerApikey:${requestKey}` ? [domain1, domain2] 
-          : key === `doppler:${requestKey}` ? [domain3] 
-          : 'dominio4.com'
-          ); }
-      });
-      const redisClient = Redis.createClient();
-      var result = await redisClient[alias](requestKey, true);
-      expect(result).to.be.eql([domain1, domain2, domain3]);
-    });
-
-    it(`${alias} should return a two elements array when there are two shops for a given Doppler API key in old format`, async function() {
-      const requestKey = 'dhnsa789dhsaiffdsfds';
-      const domain1 = 'dominio1.com';
-      const domain2 = 'dominio2.com';
-      prepareDummySandbox(this.sandbox, {
-        smembers: (key, cb) => { cb(
-          undefined, 
-          key.startsWith('shopDomainsByDopplerApikey:') ? null
-            : key === `doppler:${requestKey}` ? [domain1, domain2]
-            : 'dominio3.com'
-          ); }
-      });
-      const redisClient = Redis.createClient();
-      var result = await redisClient[alias](requestKey, true);
-      expect(result).to.be.eql([domain1, domain2]);
-    });
-
-    it(`${alias} should return an empty array when shops do not exist for a given Doppler API key`, async function() {
-      prepareDummySandbox(this.sandbox);
-      const redisClient = Redis.createClient();
-      var result = await redisClient[alias]('dhnsa789dhsaiffdsfds', true);
-      expect(result).to.be.eql([]);
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.callCount(2);
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
-        'shopDomainsByDopplerApikey:dhnsa789dhsaiffdsfds'
-      );
-      expect(mocks.wrappedRedisClient.smembers).to.have.been.calledWith(
-        'doppler:dhnsa789dhsaiffdsfds'
-      );
-      expect(mocks.wrappedRedisClient.quit).to.have.been.callCount(1);
-    });
-
-    it(`${alias} should raise the error thrown by redis`, async function() {
-      const errorMessage = 'Forced Error';
-      prepareDummySandbox(this.sandbox, {
-        smembers: (_key, cb) => { cb(new Error(errorMessage)); }
-      });
-  
-      const redisClient = Redis.createClient();
-  
-      await throwsAsync(async () => {
-        await redisClient[alias]('dhnsa789dhsaiffdsfds');
-      }, `Error retrieving shops for Doppler account. Error: ${errorMessage}`);
-    });
-  }
+    await throwsAsync(async () => {
+      await redisClient.getAllShopDomainsByDopplerApiKeyAsync('dhnsa789dhsaiffdsfds');
+    }, `Error retrieving shops for Doppler account. Error: ${errorMessage}`);
+  });
 
   it(`getAllShopDomainsByDopplerAccountNameAsync should not call quit when flag is not set`, async function() {
     prepareDummySandbox(this.sandbox);

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -4,6 +4,8 @@ const wrapAsync = require('../../helpers/wrapAsync');
 const withDoppler =  require('../../helpers/withDoppler');
 
 module.exports = function(dopplerController) {
+  // TODO: deprecate `/me/...` routes and use `/doppler/{accountName}/...` ones
+  // in place of them. In that way, we could allow SuperUser JWT tokens  
   const router = new Router();
   router.get(
     '/me/shops',

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -12,10 +12,6 @@ module.exports = {
     },
     redisClient: {
         getShopAsync: async function () {},
-        /**
-         * @deprecated use getAllShopDomainsByDopplerApiKey or getAllShopDomainsByDopplerAccountName in place
-         */
-        getShopsAsync: async function () {},
         getAllShopDomainsByDopplerApiKeyAsync: async function () {},
         getAllShopDomainsByDopplerAccountNameAsync: async function () {},
         storeShopAsync: async function () {},

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -12,6 +12,7 @@ module.exports = {
     },
     redisClient: {
         getShopAsync: async function () {},
+        getAllShopDomainsByDopplerDataAsync: async function () {},
         getAllShopDomainsByDopplerApiKeyAsync: async function () {},
         getAllShopDomainsByDopplerAccountNameAsync: async function () {},
         storeShopAsync: async function () {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
+accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -2322,7 +2322,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@~1.1.2:
+depd@^1.1.0, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -3189,7 +3189,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
@@ -4855,7 +4855,7 @@ memory-fs@~0.3.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
+merge-descriptors@1.0.1, merge-descriptors@^1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
@@ -5213,6 +5213,21 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
+
+node-mocks-http@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/node-mocks-http/-/node-mocks-http-1.7.6.tgz#b5c978d73165179a218bc9d4e3bbe73fa8bedd89"
+  integrity sha512-ZWbZ5HEEAoVZbAYM8KHezx0v66Te3klg/yhAmdJJ0ULWQAkSqPStEzqSjONj4zRZOrTWqsHnI6nHeJxw46gj6Q==
+  dependencies:
+    accepts "^1.3.7"
+    depd "^1.1.0"
+    fresh "^0.5.2"
+    merge-descriptors "^1.0.1"
+    methods "^1.1.2"
+    mime "^1.3.4"
+    parseurl "^1.3.3"
+    range-parser "^1.2.0"
+    type-is "^1.6.18"
 
 node-pre-gyp@^0.11.0:
   version "0.11.0"
@@ -5741,7 +5756,7 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
-parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.3, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -6217,7 +6232,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-range-parser@^1.2.1, range-parser@~1.2.1:
+range-parser@^1.2.0, range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
@@ -7695,7 +7710,7 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.18, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,9 +252,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "12.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
-  integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
+  version "12.6.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.3.tgz#44d507c5634f85e7164707ca36bba21b5213d487"
+  integrity sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA==
 
 "@types/node@^10.0.8":
   version "10.14.12"
@@ -351,10 +351,10 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.1.tgz#ebf8d3af22552df9dd049bfbe50cc2390e823593"
-  integrity sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -593,11 +593,11 @@ async@^1.5.2:
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.1.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
-  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1511,13 +1511,18 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.6.3:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.4.tgz#fd0638b3f8867fec2c604ed0ed9300379f8ec7c2"
-  integrity sha512-ErJT8qGfRt/VWHSr1HeqZzz50DvxHtr1fVL1m5wf20aGrG8e1ce8fpZ2EjZEfs09DDZYSvtRaDlMpWslBf8Low==
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.6.tgz#6e4bf467cde520bc9dbdf3747dafa03531cec453"
+  integrity sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==
   dependencies:
-    caniuse-lite "^1.0.30000981"
-    electron-to-chromium "^1.3.188"
+    caniuse-lite "^1.0.30000984"
+    electron-to-chromium "^1.3.191"
     node-releases "^1.1.25"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -1635,10 +1640,10 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981:
-  version "1.0.30000983"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000983.tgz#ab3c70061ca2a3467182a10ac75109b199b647f8"
-  integrity sha512-/llD1bZ6qwNkt41AsvjsmwNOoA4ZB+8iqmf5LVyeSXuBODT/hAMFNVOh84NdUzoiYiSKqo5vQ3ZzeYHSi/olDQ==
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000984:
+  version "1.0.30000984"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz#dc96c3c469e9bcfc6ad5bdd24c77ec918ea76fe0"
+  integrity sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -2462,6 +2467,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2472,10 +2484,10 @@ ejs@^2.6.2:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.2.tgz#3a32c63d1cd16d11266cd4703b14fec4e74ab4f6"
   integrity sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==
 
-electron-to-chromium@^1.3.188, electron-to-chromium@^1.3.47:
-  version "1.3.188"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.188.tgz#e28e1afe4bb229989e280bfd3b395c7ec03c8b7a"
-  integrity sha512-tEQcughYIMj8WDMc59EGEtNxdGgwal/oLLTDw+NEqJRJwGflQvH3aiyiexrWeZOETP4/ko78PVr6gwNhdozvuQ==
+electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
+  version "1.3.191"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz#c451b422cd8b2eab84dedabab5abcae1eaefb6f0"
+  integrity sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==
 
 elliptic@^6.0.0:
   version "6.5.0"
@@ -2494,6 +2506,11 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -2574,9 +2591,11 @@ eslint-scope@^4.0.3:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"
+  integrity sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
@@ -3908,9 +3927,9 @@ ini@^1.3.4, ini@~1.3.0:
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@^6.2.2:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.4.1.tgz#7bd9e5ab0567cd23b41b0180b68e0cfa82fc3c0b"
-  integrity sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
+  integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
   dependencies:
     ansi-escapes "^3.2.0"
     chalk "^2.4.2"
@@ -3918,7 +3937,7 @@ inquirer@^6.2.2:
     cli-width "^2.0.0"
     external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.12"
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^6.4.0"
@@ -4119,6 +4138,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator@^1.0.1:
   version "1.0.3"
@@ -4497,6 +4521,22 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -4511,6 +4551,23 @@ just-extend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keyv@3.0.0:
   version "3.0.0"
@@ -4725,7 +4782,42 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.6.0:
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.6.0:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -5569,7 +5661,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-locale@^3.0.0, os-locale@^3.1.0:
+os-locale@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
@@ -5926,9 +6018,9 @@ pkg-dir@^3.0.0:
     find-up "^3.0.0"
 
 portfinder@^1.0.20:
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
-  integrity sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.21.tgz#60e1397b95ac170749db70034ece306b9a27e324"
+  integrity sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"
@@ -7204,9 +7296,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
-  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
+  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -7342,6 +7434,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
+  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^5.2.0"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"
@@ -7486,14 +7587,14 @@ tabbable@^3.1.0:
   integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
 
 table@^5.2.3:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.1.tgz#0691ae2ebe8259858efb63e550b6d5f9300171e8"
-  integrity sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.3.tgz#1f6a1377966ce70a33230d9457fb48ac173d216b"
+  integrity sha512-TZwDoOgrIMgcfRxLkCCrxg8U49WQ2SfoDC/PDTeVZQ/cmOpDeJBBsHLS9r5IHXTxJKvk+lqfj97cIRy+nfGp3w==
   dependencies:
-    ajv "^6.9.1"
-    lodash "^4.17.11"
+    ajv "^6.10.2"
+    lodash "^4.17.14"
     slice-ansi "^2.1.0"
-    string-width "^3.0.0"
+    string-width "^4.1.0"
 
 tapable@^0.2.7, tapable@~0.2.5:
   version "0.2.9"
@@ -8230,7 +8331,7 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.0.0, yargs-parser@^13.1.0:
+yargs-parser@^13.0.0, yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
@@ -8264,21 +8365,20 @@ yargs@12.0.5:
     yargs-parser "^11.1.1"
 
 yargs@^13.2.2:
-  version "13.2.4"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.4.tgz#0b562b794016eb9651b98bd37acf364aa5d6dc83"
-  integrity sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
+  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
   dependencies:
     cliui "^5.0.0"
     find-up "^3.0.0"
     get-caller-file "^2.0.1"
-    os-locale "^3.1.0"
     require-directory "^2.1.1"
     require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
     string-width "^3.0.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^13.1.0"
+    yargs-parser "^13.1.1"
 
 yargs@^6.0.0:
   version "6.6.0"


### PR DESCRIPTION
He Team, 

Sorry by the big PR, I had to change many things, but I tried to split different things in more than a commit.

I added JWT validation and a way to access _shops_ using JWT payload.

It is pending for further tasks:

- [x] Accept JWT Tokens in `POST /me/synchronize-customers` and `POST /me/migrate-shop`.
- [ ] Support the JWT token payload property that identifies super users (`isSu`), it requires including the doppler account name in the URL.

Could you review?

![image](https://user-images.githubusercontent.com/1157864/61315510-4cceba80-a7d5-11e9-83c3-1576fe5bb2b4.png)
