### PR TITLE
DPRL-16880 - Fixes in prod

### DIFF
--- a/server/controllers/doppler.controller.js
+++ b/server/controllers/doppler.controller.js
@@ -39,8 +39,13 @@ class DopplerController {
 
     async migrateShop({ body }, response) {
       const redis = this.redisClientFactory.createClient();
-      const shopInstance = await redis.getShopAsync(body.shopDomain, true);
-      response.json(!!shopInstance);
+      try {
+        const shopInstance = await redis.getShopAsync(body.shopDomain, true);
+        await redis.storeShopAsync(shopDomain, shopInstance);
+        response.json(!!shopInstance);
+      } finally {
+        await redis.quitAsync();
+      }
     }
 }
 


### PR DESCRIPTION
We need to go back to the previous key format for Redis documents because it is [used by _shopify-express_ framework](https://github.com/Shopify/shopify-express/blob/a4016ea76e71f3bcfae2829384a63256c78d1494/strategies/RedisStrategy.js#L21).

I had changed it by `shopsByShopDomain:{shopDomain}`, and now I am changing it back to `{shopDomain}`.