### PR TITLE
DPLR-16948 - Support new JWT token signature

### DIFF
--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -61,7 +61,10 @@ function withDoppler(configuration) {
     } else if (/^ey[\w-]+\.ey[\w-]+\.[\w-]+$/.test(token)) {
       // JWT TOKEN
       return verifyJwtWithOldPublicKeyFallback(token, configuration.publicKey, jwtOptions, (err, decoded) => {
-        if (err) {
+        if (err && err.name == 'TokenExpiredError' && err.expiredAt) {
+          res.status(401).send(`Expired \`Authorization\` token. Expired at: ${err.expiredAt.toISOString()}. JWT Error: ${err.message}`);
+          return;
+        } else if (err) {
           res.status(401).send(`Invalid \`Authorization\` token. JWT Error: ${err.message}`);
           return;
         } else {

--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -1,9 +1,27 @@
 const jwt = require('jsonwebtoken');
 
 const publicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9DH53toQClwPYw5EjN8j
+PUvbmQ9hoi8PxfY5e9bJzoi8mAuNaP2SmmEhP5jmhJYjwwqRRaQex0+HCOO1WG13
+d6FMPCAKvV+rTnKfj59q3LyZ1uXkbk7sTp1m7aSXGAA9MPCuXjuoQNWCyqNFZtJZ
+sRS8BnZMMVfxqKz8uYk6mqrx/cFid7pCz7dfkSFZr2YRSV3xFeVeXfcoPl05xKZO
+3GEp82WRlVa3nlVrqGM1G9odjHLY8mI/jL95p+e+RUPO9aNGUp6RtGfo3vjedWdh
+4/9VDZluqL9weqK/aNc6Z/QnCghuY9BpRnnu9PIbQ7aWT6iMEvYNydUDso7NeKRH
+pQIDAQAB
+-----END PUBLIC KEY-----`;
+
+const oldPublicKey = `-----BEGIN PUBLIC KEY-----
 MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANcuJ2Ukhm7Dhd9ESISn9K31pFvmAZ0Z
 kRLTqQ3a2CPtqM8mwqoH/EU79A0GZtFh+Qn1lrTnzeBw7dINP5yiQFECAwEAAQ==
 -----END PUBLIC KEY-----`;
+
+// It is here only for backwards compatibility for some time, 
+// waiting for Doppler release with the new key. After that, directly 
+// replace it by jwt.verify.
+const verifyJwtWithOldPublicKeyFallback = (token, secretOrPublicKey, options, callback) =>
+  jwt.verify(token, secretOrPublicKey, options, (err, decoded) => 
+    err && err.name == 'JsonWebTokenError' ? jwt.verify(token, oldPublicKey, options, callback)
+    : callback(err, decoded));
 
 const defaultConfiguration = {
   publicKey,
@@ -42,7 +60,7 @@ function withDoppler(configuration) {
       return next();
     } else if (/^ey[\w-]+\.ey[\w-]+\.[\w-]+$/.test(token)) {
       // JWT TOKEN
-      return jwt.verify(token, configuration.publicKey, jwtOptions, (err, decoded) => {
+      return verifyJwtWithOldPublicKeyFallback(token, configuration.publicKey, jwtOptions, (err, decoded) => {
         if (err) {
           res.status(401).send(`Invalid \`Authorization\` token. JWT Error: ${err.message}`);
           return;

--- a/server/helpers/withDoppler.spec.js
+++ b/server/helpers/withDoppler.spec.js
@@ -111,7 +111,7 @@ describe('withDoppler middleware', () => {
     // Assert
     expect(res.statusCode).to.be.equal(401);
     expect(res._getData()).to.be.equal(
-      'Invalid `Authorization` token. JWT Error: jwt expired');
+      'Expired `Authorization` token. Expired at: 2019-05-08T15:19:16.000Z. JWT Error: jwt expired');
     expect(next.notCalled).to.be.true;
   });
 
@@ -133,7 +133,7 @@ describe('withDoppler middleware', () => {
     // Assert
     expect(res.statusCode).to.be.equal(401);
     expect(res._getData()).to.be.equal(
-      'Invalid `Authorization` token. JWT Error: jwt expired');
+      'Expired `Authorization` token. Expired at: 2019-07-12T15:41:14.000Z. JWT Error: jwt expired');
     expect(next.notCalled).to.be.true;
   });
 

--- a/server/helpers/withDoppler.spec.js
+++ b/server/helpers/withDoppler.spec.js
@@ -4,8 +4,12 @@ const httpMocks = require('node-mocks-http');
 const expect = chai.expect;
 const withDoppler = require('./withDoppler');
 
+// https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoicGlydWxvQGFhYS5jb20iLCJjdXN0b21lcklkIjoiNTU1IiwiZGF0YWh1YkN1c3RvbWVySWQiOiI1NTUiLCJpYXQiOjE1NTczMjY5NTYsImV4cCI6MTU1NzMyODc1Nn0.LO_7WY2YJpSGP0kIdvtLaDzTHhHLj66cL34zBCE_D-AaVTBLXRCqK-swaYtgGDQIzb-bDt-FKl4ipDJTXKaG47Yno6n-IhPQivlpaEGrnRPNsfbR4j6uTtVUwJ9d1r6YPjOWLensrEX0J0MH0pCt-_NayCpWhn_PUhJCWfIYJXzr4veoFruwVBAqtKflICp7zjcMb7suYDNZ9lOlzSz2FYBqfQNUKK3hhUl9voL819dqdQNCApIgDlv7Y5-hJEyLWdQPCzIOmCbPacQUQkmGKYGlbUVC2nkruuMoZYr5Bdi7KdZ1oIzjXXHp6CnuF_MaOvqMNaC014-tVRv7cOTM-Q
+const validJwtToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoicGlydWxvQGFhYS5jb20iLCJjdXN0b21lcklkIjoiNTU1IiwiZGF0YWh1YkN1c3RvbWVySWQiOiI1NTUiLCJpYXQiOjE1NTczMjY5NTYsImV4cCI6MTU1NzMyODc1Nn0.LO_7WY2YJpSGP0kIdvtLaDzTHhHLj66cL34zBCE_D-AaVTBLXRCqK-swaYtgGDQIzb-bDt-FKl4ipDJTXKaG47Yno6n-IhPQivlpaEGrnRPNsfbR4j6uTtVUwJ9d1r6YPjOWLensrEX0J0MH0pCt-_NayCpWhn_PUhJCWfIYJXzr4veoFruwVBAqtKflICp7zjcMb7suYDNZ9lOlzSz2FYBqfQNUKK3hhUl9voL819dqdQNCApIgDlv7Y5-hJEyLWdQPCzIOmCbPacQUQkmGKYGlbUVC2nkruuMoZYr5Bdi7KdZ1oIzjXXHp6CnuF_MaOvqMNaC014-tVRv7cOTM-Q';
+
 // https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoiYW1vc2NoaW5pQG1ha2luZ3NlbnNlLmNvbSIsImN1c3RvbWVySWQiOiIxMzY3IiwiZGF0YWh1YkN1c3RvbWVySWQiOiIxMzY3IiwiaWF0IjoxNTYyOTQ0Mjc0LCJleHAiOjE1NjI5NDYwNzR9.UCPZT4AS3DvPl91XhU8adc5Zb7oUdN0mxQyIy4N78LZYcNSSGmoIGfbmXXgRZ0M6KGRUnCgnSOAqW6uaBFn9kQ
-const validJwtToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoiYW1vc2NoaW5pQG1ha2luZ3NlbnNlLmNvbSIsImN1c3RvbWVySWQiOiIxMzY3IiwiZGF0YWh1YkN1c3RvbWVySWQiOiIxMzY3IiwiaWF0IjoxNTYyOTQ0Mjc0LCJleHAiOjE1NjI5NDYwNzR9.UCPZT4AS3DvPl91XhU8adc5Zb7oUdN0mxQyIy4N78LZYcNSSGmoIGfbmXXgRZ0M6KGRUnCgnSOAqW6uaBFn9kQ';
+const validOldJwtToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1N1IjpmYWxzZSwic3ViIjoiYW1vc2NoaW5pQG1ha2luZ3NlbnNlLmNvbSIsImN1c3RvbWVySWQiOiIxMzY3IiwiZGF0YWh1YkN1c3RvbWVySWQiOiIxMzY3IiwiaWF0IjoxNTYyOTQ0Mjc0LCJleHAiOjE1NjI5NDYwNzR9.UCPZT4AS3DvPl91XhU8adc5Zb7oUdN0mxQyIy4N78LZYcNSSGmoIGfbmXXgRZ0M6KGRUnCgnSOAqW6uaBFn9kQ';
+
 
 describe('withDoppler middleware', () => {
   it('should return 401 error when there is not an authorization header', () => {
@@ -111,6 +115,28 @@ describe('withDoppler middleware', () => {
     expect(next.notCalled).to.be.true;
   });
 
+  it('should return 401 error when Old JWT token is expired', () => {
+    // Arrange
+    const middleware = withDoppler();
+ 
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: `token ${validOldJwtToken}`
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(res.statusCode).to.be.equal(401);
+    expect(res._getData()).to.be.equal(
+      'Invalid `Authorization` token. JWT Error: jwt expired');
+    expect(next.notCalled).to.be.true;
+  });
+
   it('should fill dopplerData.tokenJwt when token has a valid JWT format', () => {
     // Arrange
     const middleware = withDoppler({ ignoreExpiration: true });
@@ -133,6 +159,33 @@ describe('withDoppler middleware', () => {
     expect(req.dopplerData).to.not.have.property('apiKey');
     expect(req.dopplerData.tokenJwt).to.equal(validJwtToken);
     expect(req.dopplerData.isSuperUser).to.be.false;
+    expect(req.dopplerData.accountName).to.equal('pirulo@aaa.com');
+    expect(res.statusCode).to.be.equal(200);
+  });
+
+  it('should fill dopplerData.tokenJwt when Old token has a valid JWT format', () => {
+    // Arrange
+    const middleware = withDoppler({ ignoreExpiration: true });
+
+    const req = httpMocks.createRequest({ 
+      headers: {
+        Authorization: `token ${validOldJwtToken}`
+      }
+    });
+    const res = httpMocks.createResponse();
+    var next = sinon.spy();
+    
+    // Act
+    middleware(req, res, next);
+
+    // Assert
+    expect(next.calledOnce).to.be.true;
+    expect(req).to.have.property('dopplerData');
+    expect(req.dopplerData).to.have.property('tokenJwt');
+    expect(req.dopplerData).to.not.have.property('apiKey');
+    expect(req.dopplerData.tokenJwt).to.equal(validOldJwtToken);
+    expect(req.dopplerData.isSuperUser).to.be.false;
     expect(req.dopplerData.accountName).to.equal('amoschini@makingsense.com');
+    expect(res.statusCode).to.be.equal(200);
   });
 });


### PR DESCRIPTION
Hi team,

These changes allow us to support the old 512 bits JWT key and the new 2048 bits one.

By the way, I found that we were not paying special attention to expired tokens, so tried to improve the error message.

@leoslopez, maybe this code could be useful for you in DataHub.

CC: @mmosquera, @javierburger, @CarlosPintos 