### PR TITLE
feat: allow read ETag header in CORS requests

### DIFF
--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -872,6 +872,22 @@ describe('Server integration tests', function() {
         });
     });
 
+    it('Should accept OPTIONS CORS request from localhost', async function() {
+      await request(app)
+        .options('/me/shops')
+        .set('Authorization', `token ${dopplerApiKey}`)
+        .set('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:68.0) Gecko/20100101 Firefox/68.0')
+        .set('Accept', '*/*')
+        .set('Referer', 'http://localhost:3000/')
+        .set('Origin', 'http://localhost:3000')
+        .expect(function(res) {
+          expect(res.get('Access-Control-Allow-Origin')).to.be.eql('http://localhost:3000');
+          expect(res.get('Access-Control-Allow-Methods')).to.be.eql('GET,HEAD,PUT,PATCH,POST,DELETE');
+          expect(res.get('Access-Control-Allow-Headers')).to.be.eql('Content-Type,Authorization,Accept');
+          expect(res.get('Access-Control-Allow-Credentials')).to.be.eql('true');
+        });
+    });
+
     it('Should not accept GET CORS request from arbitrary origin', async function() {
       await request(app)
         .get('/me/shops')

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -727,6 +727,19 @@ describe('Server integration tests', function() {
         });
     });
 
+    it('Should include ETag in Access-Control-Expose-Headers in response', async function() {
+      await request(app)
+        .get('/me/shops')
+        .set('Authorization', `token ${dopplerApiKey}`)
+        .set('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:68.0) Gecko/20100101 Firefox/68.0')
+        .set('Accept', '*/*')
+        .set('Referer', 'https://app.fromdoppler.com/')
+        .set('Origin', 'https://app.fromdoppler.com')
+        .expect(function(res) {
+          expect(res.get('Access-Control-Expose-Headers')).to.be.eql('ETag');
+        });
+    });
+
     it('Should accept OPTIONS CORS request from https://app.fromdoppler.com', async function() {
       await request(app)
         .options('/me/shops')

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -13,7 +13,8 @@ const corsHandler = cors({
     'https://app.fromdoppler.com:4443',
     'https://app.fromdoppler.com:4444'
   ],
-  allowedHeaders: ['Content-Type', 'Authorization', 'Accept']
+  allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],
+  exposedHeaders: ['ETag']
 });
 module.exports = function(dopplerController) {
   // TODO: deprecate `/me/...` routes and use `/doppler/{accountName}/...` ones

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -7,11 +7,8 @@ var cors = require('cors');
 const corsHandler = cors({
   credentials: true,
   origin: [
-    'https://app.fromdoppler.com',
-    'http://cdn.fromdoppler.com',
-    'https://cdn.fromdoppler.com',
-    'https://app.fromdoppler.com:4443',
-    'https://app.fromdoppler.com:4444',
+    /^http(s)?:\/\/cdn.fromdoppler.com(:\d+)?$/,
+    /^http(s)?:\/\/app.fromdoppler.com(:\d+)?$/,
     /^http(s)?:\/\/localhost(:\d+)?$/
   ],
   allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -11,7 +11,8 @@ const corsHandler = cors({
     'http://cdn.fromdoppler.com',
     'https://cdn.fromdoppler.com',
     'https://app.fromdoppler.com:4443',
-    'https://app.fromdoppler.com:4444'
+    'https://app.fromdoppler.com:4444',
+    /^http(s)?:\/\/localhost(:\d+)?$/
   ],
   allowedHeaders: ['Content-Type', 'Authorization', 'Accept'],
   exposedHeaders: ['ETag']


### PR DESCRIPTION
Hi Team, 

@cbernat is applying an optimization in WebApp side and she needs to read `ETag` header in Our Shopify API response.

![image](https://user-images.githubusercontent.com/1157864/64619102-e5d61800-d3b7-11e9-99db-4a8c3556782b.png)

The header is there, but she cannot read it because of [CORS restrictions](https://stackoverflow.com/questions/37897523/axios-get-access-to-response-header-fields#37931084).

This change wants to fix it. In the future we need to apply similar changes in DataHub API and Doppler, could you review?

@cbernat, @javierburger, @leoslopez, @elsupergomez, @CarlosSampedro