### PR TITLE
Filter empty emails in import

### DIFF
--- a/server/controllers/app.controller.js
+++ b/server/controllers/app.controller.js
@@ -256,7 +256,8 @@ class AppController {
         let customers = [];
         for (let pageNumber = 1; pageNumber <= totalCustomers/shopifyCustomersPageSize + 1; pageNumber++)
         {
-          customers = customers.concat(await shopify.customer.list({ limit: shopifyCustomersPageSize, page: pageNumber }));
+          customers = customers.concat((await shopify.customer.list({ limit: shopifyCustomersPageSize, page: pageNumber }))
+            .filter(customer => !!customer.email));
         }
 
         lastStep = 'send-data-to-doppler';


### PR DESCRIPTION
This PR will fix the problem when sincronizing customers with empty or null emails.
Ticket support: Doppler id 219031 Error Shopify

![image](https://user-images.githubusercontent.com/53189627/65181865-6343fd00-da36-11e9-8ab5-94f005e871e7.png)

![image](https://user-images.githubusercontent.com/53189627/65181786-37c11280-da36-11e9-9e9c-6c0cc5d92339.png)
