### PR TITLE
fix: configure auth cookie as secure and samesite

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -85,6 +85,8 @@ app.use(
     secret: SHOPIFY_APP_SECRET,
     resave: true,
     saveUninitialized: false,
+    secure: true, 
+    sameSite: 'none',
   })
 );
 


### PR DESCRIPTION
See:
* https://partners.shopify.com/786029/samesite_cookies_warning
* https://help.shopify.com/en/api/guides/samesite-cookies
* https://github.com/expressjs/session/blob/4d253405aca773e3e994c0259a3bc658c22430e0/README.md#user-content-cookiesamesite
* https://www.seerinteractive.com/blog/samesite-security-update-chrome/