### PR TITLE
[dop-170] Using Redis to get shop's accessToken instead session 

### DIFF
--- a/server/controllers/app.controller.js
+++ b/server/controllers/app.controller.js
@@ -105,7 +105,7 @@ class AppController {
       await redis.storeShopAsync(
         shop,
         { dopplerAccountName, dopplerApiKey, connectedOn: new Date().toISOString(), synchronizedCustomersCount: 0 });
-        const shopInstance = await redis.getShopAsync(shop, true);
+      const shopInstance = await redis.getShopAsync(shop, true);
       await doppler.putShopifyIntegrationAsync(shop, shopInstance.accessToken);
     } catch (error) {
       await redis.removeShopAsync(shop);
@@ -226,7 +226,7 @@ class AppController {
   }
 
   //TODO: this is a heavyweight process, maybe we should do it all asynchronous
-  async synchronizeCustomers({ query: { force }, session: { shop, accessToken } }, response) {
+  async synchronizeCustomers({ query: { force }, session: { shop } }, response) {
     // undefined and null will be false
     // '', 0, 'false', 'true', another string, number or object will be true
     // POST /synchronize-customers?force => true
@@ -250,7 +250,7 @@ class AppController {
           });
 
         lastStep = 'count-customers';
-        const shopify = this.shopifyClientFactory.createClient(shop, accessToken);
+        const shopify = this.shopifyClientFactory.createClient(shop, shopInstance.accessToken);
         const totalCustomers = await shopify.customer.count();
 
         lastStep = 'prepare-customers-list';

--- a/server/controllers/app.controller.js
+++ b/server/controllers/app.controller.js
@@ -88,7 +88,7 @@ class AppController {
     });
   }
 
-  async connectToDoppler({ session: { accessToken, shop }, body: { dopplerAccountName, dopplerApiKey } }, response) {
+  async connectToDoppler({ session: { shop }, body: { dopplerAccountName, dopplerApiKey } }, response) {
     const doppler = this.dopplerClientFactory.createClient(
       dopplerAccountName,
       dopplerApiKey
@@ -105,7 +105,8 @@ class AppController {
       await redis.storeShopAsync(
         shop,
         { dopplerAccountName, dopplerApiKey, connectedOn: new Date().toISOString(), synchronizedCustomersCount: 0 });
-      await doppler.putShopifyIntegrationAsync(shop, accessToken);
+        const shopInstance = await redis.getShopAsync(shop, true);
+      await doppler.putShopifyIntegrationAsync(shop, shopInstance.accessToken);
     } catch (error) {
       await redis.removeShopAsync(shop);
       throw error;

--- a/server/controllers/app.controller.spec.js
+++ b/server/controllers/app.controller.spec.js
@@ -176,9 +176,10 @@ describe('The app controller', function() {
 
   it('connectToDoppler should call put Doppler integration using Doppler Client', async function() {
     const shop = 'store.myshopify.com';
-    const accessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
+    const storedAccessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
+    const sessionAccessToken = 'WRONG123456';
     const request = sinonMock.mockReq({
-      session: { shop, accessToken },
+      session: { shop, accessToken : sessionAccessToken },
       body: {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',
         dopplerAccountName: 'user@example.com',
@@ -189,7 +190,7 @@ describe('The app controller', function() {
     this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'quitAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
-    .returns(Promise.resolve({ accessToken: '127424ab9aa0ebce26dfdc786bc7fba4'}));
+    .returns(Promise.resolve({ accessToken: storedAccessToken}));
     
     this.sandbox
       .stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
@@ -210,16 +211,17 @@ describe('The app controller', function() {
     expect(modulesMocks.dopplerClient.putShopifyIntegrationAsync)
       .to.have.been.callCount(1);
     expect(modulesMocks.dopplerClient.putShopifyIntegrationAsync)
-      .to.be.called.calledWithMatch(shop, accessToken);
+      .to.be.called.calledWithMatch(shop, storedAccessToken);
     expect(response.sendStatus)
       .to.be.called.calledWithExactly(200);
   });
 
   it('connectToDoppler remove the shop when putShopifyIntegrationAsync fails', async function() {
     const shop = 'store.myshopify.com';
-    const accessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
+    const storedAccessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
+    const sessionAccessToken = 'WRONG123456';
     const request = sinonMock.mockReq({
-      session: { shop, accessToken },
+      session: { shop, accessToken : sessionAccessToken },
       body: {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',
         dopplerAccountName: 'user@example.com',
@@ -231,7 +233,7 @@ describe('The app controller', function() {
     this.sandbox.stub(modulesMocks.redisClient, 'removeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'quitAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
-    .returns(Promise.resolve({ accessToken: '127424ab9aa0ebce26dfdc786bc7fba4'}));
+    .returns(Promise.resolve({ accessToken: storedAccessToken}));
     
     this.sandbox
       .stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
@@ -254,7 +256,7 @@ describe('The app controller', function() {
       expect(modulesMocks.dopplerClient.putShopifyIntegrationAsync)
         .to.have.been.callCount(1);
       expect(modulesMocks.dopplerClient.putShopifyIntegrationAsync)
-        .to.be.called.calledWithMatch(shop, accessToken);    
+        .to.be.called.calledWithMatch(shop, storedAccessToken);    
       expect(modulesMocks.redisClient.removeShopAsync)
         .to.be.called.calledWithMatch(shop);
       expect(modulesMocks.redisClient.quitAsync)

--- a/server/controllers/app.controller.spec.js
+++ b/server/controllers/app.controller.spec.js
@@ -179,7 +179,7 @@ describe('The app controller', function() {
     const storedAccessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
     const sessionAccessToken = 'WRONG123456';
     const request = sinonMock.mockReq({
-      session: { shop, accessToken : sessionAccessToken },
+      session: { shop, accessToken: sessionAccessToken },
       body: {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',
         dopplerAccountName: 'user@example.com',
@@ -221,7 +221,7 @@ describe('The app controller', function() {
     const storedAccessToken = '127424ab9aa0ebce26dfdc786bc7fba4';
     const sessionAccessToken = 'WRONG123456';
     const request = sinonMock.mockReq({
-      session: { shop, accessToken : sessionAccessToken },
+      session: { shop, accessToken: sessionAccessToken },
       body: {
         dopplerApiKey: 'C22CADA13759DB9BBDF93B9D87C14D5A',
         dopplerAccountName: 'user@example.com',

--- a/server/controllers/app.controller.spec.js
+++ b/server/controllers/app.controller.spec.js
@@ -139,9 +139,13 @@ describe('The app controller', function() {
         dopplerAccountName: 'user@example.com',
       },
     });
+
     const response = sinonMock.mockRes();
+
     this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'quitAsync');
+    this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+    .returns(Promise.resolve({ accessToken: 'ae768b8c78d68a54565434'}));
     this.sandbox
       .stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
       .returns(Promise.resolve(true));
@@ -184,6 +188,8 @@ describe('The app controller', function() {
 
     this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'quitAsync');
+    this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+    .returns(Promise.resolve({ accessToken: '127424ab9aa0ebce26dfdc786bc7fba4'}));
     
     this.sandbox
       .stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')
@@ -224,6 +230,8 @@ describe('The app controller', function() {
     this.sandbox.stub(modulesMocks.redisClient, 'storeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'removeShopAsync');
     this.sandbox.stub(modulesMocks.redisClient, 'quitAsync');
+    this.sandbox.stub(modulesMocks.redisClient, 'getShopAsync')
+    .returns(Promise.resolve({ accessToken: '127424ab9aa0ebce26dfdc786bc7fba4'}));
     
     this.sandbox
       .stub(modulesMocks.dopplerClient, 'AreCredentialsValidAsync')

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -238,6 +238,14 @@ describe('Server integration tests', function() {
     });
 
     it('Should return 200 status code when valid Doppler credentials', async function() {
+      this.sandbox
+      .stub(mocks.wrappedRedisClient, 'hgetall')
+      .callsFake((_key, cb) => {
+        cb(null, {
+          accessToken: accessToken,
+          dopplerAccountName: dopplerAccountName,
+        });
+      });
       fetchStub
         .withArgs(
           `https://restapi.fromdoppler.com/accounts/${querystring.escape(
@@ -278,7 +286,7 @@ describe('Server integration tests', function() {
           })
         );
 
-      await request(app)
+        await request(app)
         .post('/connect-to-doppler')
         .send({ dopplerAccountName, dopplerApiKey })
         .set('cookie', cookie)

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -286,7 +286,7 @@ describe('Server integration tests', function() {
           })
         );
 
-        await request(app)
+      await request(app)
         .post('/connect-to-doppler')
         .send({ dopplerAccountName, dopplerApiKey })
         .set('cookie', cookie)

--- a/server/modules/doppler-client.js
+++ b/server/modules/doppler-client.js
@@ -271,6 +271,9 @@ class Doppler {
 
   async putShopifyIntegrationAsync(shopDomain, accessToken) {
     const url = `${baseUrl}/accounts/${this.accountName}/integrations/shopify`;
+    // TODO: Remove logs
+    console.info(shopDomain);
+    console.info(accessToken);
     await sendRequestAsync(this.fetch, url, {
         method: 'PUT',
         body: JSON.stringify({

--- a/server/modules/doppler-client.js
+++ b/server/modules/doppler-client.js
@@ -271,9 +271,7 @@ class Doppler {
 
   async putShopifyIntegrationAsync(shopDomain, accessToken) {
     const url = `${baseUrl}/accounts/${this.accountName}/integrations/shopify`;
-    // TODO: Remove logs
-    console.info(shopDomain);
-    console.info(accessToken);
+    console.info(`[putShopifyIntegrationAsync] shopDomain: ${shopDomain}; accessToken: ${accessToken}`);
     await sendRequestAsync(this.fetch, url, {
         method: 'PUT',
         body: JSON.stringify({

--- a/test-utilities/modules-mock.js
+++ b/test-utilities/modules-mock.js
@@ -13,7 +13,7 @@ const factories = {
     srem: () => {},
   }),
   redisClient: () => ({
-    getShopAsync: function() {},
+    getShopAsync: () => {},
     getAllShopDomainsByDopplerDataAsync: () => {},
     getAllShopDomainsByDopplerApiKeyAsync: () => {},
     getAllShopDomainsByDopplerAccountNameAsync: () => {},


### PR DESCRIPTION
### [dop-170] Using Redis to get shop's accessToken instead session 
- Changed Doppler's putShopifyIntegrationAsync to get accessToken from Redis instead session
- Added logs in putShopifyIntegrationAsync to track the accessToken sent to Doppler
- Fixed tests
