### PR TITLE
add unistallShop method

### DIFF
--- a/server/helpers/withDoppler.js
+++ b/server/helpers/withDoppler.js
@@ -72,7 +72,7 @@ function withDoppler(configuration) {
           req.dopplerData = { 
             tokenJwt: token,
             accountName: decoded.sub,
-            isSuperUser: !!decoded.isSu,
+            isSuperUser: !!decoded.isSU,
           };
           return next();
         }

--- a/server/index.js
+++ b/server/index.js
@@ -41,7 +41,8 @@ const hooksController = new HooksController(
 );
 const dopplerController = new DopplerController(
   redisClientFactory,
-  appController
+  appController,
+  dopplerClientFactory
 );
 
 const {

--- a/server/index.spec.js
+++ b/server/index.spec.js
@@ -781,6 +781,27 @@ describe('Server integration tests', function() {
     });
   });
 
+  describe('POST /me/uninstall', function() {
+    it('Should return 401 status code when there is not authorization header present', async function() {
+      await request(app)
+        .post('/me/uninstall')
+        .expect(function(res) {
+          expect(res.statusCode).to.be.eql(401);
+          expect('Missing `Authorization` header').to.be.eql(res.text);
+        });
+    });
+
+    it('Should return 403 status code when token is an APIKEY', async function() {
+      await request(app)
+        .post('/me/uninstall')
+        .set('Authorization', `token ${dopplerApiKey}`)
+        .expect(function(res) {
+          expect(res.statusCode).to.be.eql(403);
+          expect(res.text).to.be.eql('Super user is required.');
+        });
+    });
+  });
+
   describe('GET /me/shops', function() {
     it('Should return 401 status code when there is not authorization header present', async function() {
       await request(app)

--- a/server/routes/doppler/routes.js
+++ b/server/routes/doppler/routes.js
@@ -40,5 +40,11 @@ module.exports = function(dopplerController) {
     json(),
     wrapAsync((req, res) => dopplerController.migrateShop(req, res))
   );
+  router.post(
+    '/me/uninstall',
+    withDoppler(),
+    json(),
+    wrapAsync((req, res) => dopplerController.uninstallShop(req, res))
+  );
   return router;
 };


### PR DESCRIPTION
This pull reques is to avoid uninstall shop in shopify integration.
This functionality will be used by L2 by request to the Shopify integration, should have the superUser permission and the name of the store to delete as parameters.
This method will facilitate the implementation of the same method to be used from the Doppler application by users in the future.

Fixes: Doppler id 309010 Desincronizar integración

### Checklist:
Por favor, no borrar items del checklist. El tilde significa que "lo hice" o que "puedo confirmar que mis cambios no afectan ese aspecto".

 - [x] I have paid attention to this PR title and description
 - [x] I have performed a self-review of my code
 - [ ] I have built it locally (or my changes does not affect the build)
 - [ ] I have checked all tests still run ok at Doppler.UnitTests project
 - [ ] I have tested minified js scripts (or there are not modified files included in cassette bundle, see more information here)
 - [ ] I have run Hypermedia API tests locally (or I can confirm that my changes do not break those tests)
 - [x] I have checked if I introduced new DI dependencies in all required places (or I did not include any dependency)
 - [x] I have added all the new files into project files (.csproj, etc) (Or there are not new files)
 - [x] I have added all scripts for DB (Or there are no new scripts)
 - [x] I have updated Script.PostDeployment.sql (or I do not add new data nor DB structural changes that affect existing inserts)
 - [x] I have tested applying and rolling back DB scripts twice (Or there are not DB changes)